### PR TITLE
add trottercircuitandparams

### DIFF
--- a/src/PauliAlgebra/utils.jl
+++ b/src/PauliAlgebra/utils.jl
@@ -89,6 +89,29 @@ function getpauli(pstr::PauliStringType, index::Integer)
 end
 
 """
+    getpaulisandinds(pstr::PauliStringType)
+
+Returns `(paulis,indices)`` where `paulis` are all non-identity paulis contained in the
+given Pauli string (as symbols `:X`, `:Y`, `:Z`) and `indices` are their corresponding indices
+"""
+function getpaulisandinds(pstr::PauliStringType)
+    paulis::Vector{Symbol} = []
+    indices::Vector{Int} = []
+
+    maxind = ndigits(pstr, base=2)
+
+    for i in 1:maxind
+        p = getpauli(pstr, i)
+        if (p != 0)
+            push!(paulis, pauli_symbols[p+1])
+            push!(indices, i)
+        end
+    end
+    
+    return (paulis, indices)
+end
+
+"""
     setpauli(pstr::PauliString, target_pauli::T, index::Integer) where {T<:Union{Symbol,PauliType}}
 
 Sets the Pauli on index `index` of an integer `PauliString` to `target_pauli`. That Pauli can be provided as integer (0, 1, 2, 3) or as a symbol (:I, :X, :Y, :Z).

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -78,6 +78,7 @@ export
     efficientsu2circuit,
     tfitrottercircuit,
     heisenbergtrottercircuit,
+    trottercircuitandparams,
     su4ansatz,
     qcnnansatz,
     appendSU4!


### PR DESCRIPTION
which produces higher-order symmetrized Suzuki-Trotter circuits, randomising each repetition therein (to the dismay of Yanting).

Do not merge this before revising PauliGate within to PauliRotation, as per PR #32