### PR TITLE
Allow fully static or frozen circuits to work without thetas

### DIFF
--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -132,8 +132,6 @@ export
 include("Surrogate/Surrogate.jl")
 export
     NodePathProperties,
-    EvalEndNode,
-    PauliRotationNode,
     evaluate!,
     reset!
 

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -5,11 +5,12 @@
 ##
 ###
 """
-    propagate(circ, pstr::PauliString, thetas; kwargs...)
+    propagate(circ, pstr::PauliString, thetas=nothing; kwargs...)
 
 Propagate a `PauliString` through the circuit `circ` in the Heisenberg picture. 
 This means that the circuit is applied to the Pauli string in reverse order, and the action of each gate is its conjugate action.
 Parameters for the parametrized gates in `circ` are given by `thetas`, and need to be passed as if the circuit was applied as written in the Schrödinger picture.
+If thetas are not passed, the circuit must contain only non-parametrized `StaticGates`.
 `kwargs` are passed to the truncation function. Supported by default are `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
 A custom truncation function can be passed as `customtruncatefn` with the signature customtruncatefn(pstr::PauliStringType, coefficient)::Bool.
 """
@@ -19,11 +20,12 @@ function propagate(circ, pstr::PauliString, thetas=nothing; kwargs...)
 end
 
 """
-    propagate(circ, psum, thetas; kwargs...)
+    propagate(circ, psum, thetas=nothing; kwargs...)
 
 Propagate a `PauliSum` through the circuit `circ` in the Heisenberg picture. 
 This means that the circuit is applied to the Pauli sum in reverse order, and the action of each gate is its conjugate action.
 Parameters for the parametrized gates in `circ` are given by `thetas`, and need to be passed as if the circuit was applied as written in the Schrödinger picture.
+If thetas are not passed, the circuit must contain only non-parametrized `StaticGates`.
 `kwargs` are passed to the truncation function. Supported by default are `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
 A custom truncation function can be passed as `customtruncatefn` with the signature customtruncatefn(pstr::PauliStringType, coefficient)::Bool.
 """
@@ -34,12 +36,13 @@ end
 
 
 """
-    propagate!(circ, psum, thetas; kwargs...)
+    propagate!(circ, psum, thetas=nothing; kwargs...)
 
 Propagate a Pauli sum  through the circuit `circ` in the Heisenberg picture. 
 This means that the circuit is applied to the Pauli sum in reverse order, and the action of each gate is its conjugate action.
 The input `psum` will be modified.
 Parameters for the parametrized gates in `circ` are given by `thetas`, and need to be passed as if the circuit was applied as written in the Schrödinger picture.
+If thetas are not passed, the circuit must contain only non-parametrized `StaticGates`.
 `kwargs` are passed to the truncation function. Supported by default are `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
 A custom truncation function can be passed as `customtruncatefn` with the signature customtruncatefn(pstr::PauliStringType, coefficient)::Bool.
 """

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -29,7 +29,7 @@ If thetas are not passed, the circuit must contain only non-parametrized `Static
 `kwargs` are passed to the truncation function. Supported by default are `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
 A custom truncation function can be passed as `customtruncatefn` with the signature customtruncatefn(pstr::PauliStringType, coefficient)::Bool.
 """
-function propagate(circ, psum::PauliSum, thetas=nothing; kwargs...)
+function propagate(circ, psum, thetas=nothing; kwargs...)
     psum = propagate!(circ, deepcopy(psum), thetas; kwargs...)
     return psum
 end
@@ -46,7 +46,7 @@ If thetas are not passed, the circuit must contain only non-parametrized `Static
 `kwargs` are passed to the truncation function. Supported by default are `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
 A custom truncation function can be passed as `customtruncatefn` with the signature customtruncatefn(pstr::PauliStringType, coefficient)::Bool.
 """
-function propagate!(circ, psum::PauliSum, thetas=nothing; kwargs...)
+function propagate!(circ, psum, thetas=nothing; kwargs...)
     # if thetas is nothing, the circuit must contain only StaticGates
     if isnothing(thetas)
         if any(gate isa ParametrizedGate for gate in circ)


### PR DESCRIPTION
Here is a snipped of code that now works:
```
circ = [PauliRotation(:X, 1, 0.2), PauliRotation(:X, 2, 0.2)]
pstr = PauliString(2, [:Z, :Z], [1, 2])
propagate(circ, pstr)
```
Before, it would have been
```
circ = [PauliRotation(:X, 1, 0.2), PauliRotation(:X, 2, 0.2)]
pstr = PauliString(2, [:Z, :Z], [1, 2])
propagate(circ, pstr, [0])  # with a dummy list of thetas
```
This allows people to not deal with passed thetas if the circuit is fully static. It also means people can define their propagation at the time of circuit definition, which I think most people like.