### PR TITLE
[feature] Support for computing Pauli transfer matrix given a unitary matrix.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Bits = "1654ce90-6ed3-553a-957f-9452c3a40996"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -102,6 +102,19 @@ export
     mergeandempty!,
     merge
 
+include("PauliTransferMatrix/unitaries.jl")
+export
+    TUnitary,
+    U1Unitary,
+    get_unitary_dagmat,
+    constant_pauli_basis_n_qubits,
+    pauli_basis
+
+include("PauliTransferMatrix/paulitransfermaps.jl")
+export
+    calc_ptm_dagmap,
+    get_ptm_sparse
+
 include("stateoverlap.jl")
 export
     overlapbyorthogonality,

--- a/src/PauliTransferMatrix/PauliTransferMatrix.jl
+++ b/src/PauliTransferMatrix/PauliTransferMatrix.jl
@@ -1,0 +1,2 @@
+# unitaries.jl contrains implementations of local qubit unitaries.
+include("unitaries.jl")

--- a/src/PauliTransferMatrix/paulitransfermaps.jl
+++ b/src/PauliTransferMatrix/paulitransfermaps.jl
@@ -1,0 +1,96 @@
+using SparseArrays
+
+
+"""
+    function calc_ptm_dagmap(udag; tol=1e-15, symmetry=nothing)
+
+Arguments
+- `udag::Array{}`: The unitary matrix for which the PTM is calculated.
+- `tol::Float64=1e-15`: The tolerance for dropping small values in the PTM.
+- `symmetry::Array{}`: The symmetry matrix to apply to the PTM.
+    If no symmetry is provided, the PTM is computed in the Pauli basis.
+
+Returns
+- `ptm::SparseMatrixCSC`: The PTM of the unitary matrix `udag`.
+"""
+function calc_ptm_dagmap(udag; tol=1e-15, symmetry=nothing)
+
+    nqubits = Int(log(2, size(udag)[1]))
+
+    # Write ptm as a sprase matrix
+    ptm = spzeros(Float64, 4^nqubits, 4^nqubits)
+
+    # The pauli basis vector is defined to be consistent with index of the pstr
+    pauli_basis_vec = constant_pauli_basis_n_qubits(nqubits)
+
+    # We are taking udag as the actual unitary, and the PTM is defined by
+    # evolving P_j and take overlap with P_i
+    # PTM_{ij} = Tr(udag * P_j * udag^{\dagger} * P_i)
+    # in the Pauli basis, this is always real.
+    for i in 1:4^nqubits
+        for j in 1:4^nqubits
+            ptm[i, j] = real(
+                tr(udag * pauli_basis_vec[j] * udag' * pauli_basis_vec[i])
+            )
+        end
+    end
+
+    if symmetry != nothing
+        ptm = sparse(inv(symmetry) * ptm * symmetry)
+    end
+
+    droptol!(ptm, tol)  # Here tol is relevant to the input pstr.
+
+    return ptm  # return the ptm as a sparse matrix
+end
+
+"""
+    function get_ptm_sparse(ptm::SparseMatrixCSC, type::DataType)
+
+Arguments
+- `ptm::SparseMatrixCSC`: The PTM in sparse matrix format.
+- `type::Function`: The type to apply to the indices of the PTM.
+
+Returns
+- `ptm_map::Vector{Tuple}`: The PTM in a sparse format.
+"""
+function get_ptm_sparse(ptm::SparseMatrixCSC, type)
+    ptm_map = Vector{Tuple}()
+    for j in 1:size(ptm, 2) # loop over columns
+        rows, vals = findnz(view(ptm, :, j))
+        rows = [i - 1 for i in rows] # convert to 0-based indexing used for PP
+        # Create a tuple of the form (p1, c1, p2, c2, ...)
+        column_tuple = Tuple(Iterators.flatten(zip(type.(rows), vals)))
+        push!(ptm_map, column_tuple)
+    end
+    return ptm_map
+end
+
+"""
+    function get_ptm_sparse(ptm::Array, type::DataType)
+
+Arguments
+- `ptm::Array`: The PTM in matrix format.
+- `type::Function`: The type to apply to the indices of the PTM.
+
+Returns
+- `ptm_map::Vector{Tuple}`: The PTM in a sparse format.
+"""
+function get_ptm_sparse(ptm, type)
+
+    ptm_map = Vector{Tuple}()
+    rows = collect(range(0, size(ptm, 1) - 1)) # convert to 0-based indexing used for PP
+
+    for j in 1:size(ptm, 2) # loop over columns
+
+        # find non-zero elements
+        rows = findall(!iszero, ptm[:, j])
+        vals = ptm[rows, j]
+        rows_0based = [i - 1 for i in rows] # convert to 0-based indexing used for PP
+
+        push!(ptm_map, Tuple(Iterators.flatten(zip(type.(rows_0based), vals))))
+
+    end
+    return ptm_map
+end
+

--- a/src/PauliTransferMatrix/unitaries.jl
+++ b/src/PauliTransferMatrix/unitaries.jl
@@ -1,0 +1,143 @@
+###
+##
+# This file contains implementations of certain unitary gates.
+# Support gates are local unitaries, such as one-qubit, two-qubit Pauli gates.
+# Note our convetion is to define the conjugate transpose of the unitary matrix.
+# In the propagation, the circuit is ran in the reverse order, so defining the
+# conjugate transpose of the unitary matrix is more convenient.
+##
+###
+
+# module unitaries
+
+using LinearAlgebra
+
+struct U1Unitary <: ParametrizedGate
+    nparams::Int
+    qinds::Vector{Int}
+end
+
+struct TUnitary <: StaticGate
+    qinds::Vector{Int}
+end
+
+const Idmat = [1 0; 0 1]
+const Xmat = [0 1; 1 0]
+const Ymat = [0 -1im; 1im 0]
+const Zmat = [1 0; 0 -1]
+
+const pauli_basis = [Idmat / sqrt(2), Xmat / sqrt(2), Ymat / sqrt(2), Zmat / sqrt(2)]
+
+"""
+    function constant_pauli_basis_n_qubits(n::Int)
+
+Compute the Pauli basis for `n` qubits.
+
+Arguments
+- `n::Int`: The number of qubits.
+
+Returns
+- `basis::Vector{Array{ComplexF64}}`: The Pauli basis for `n` qubits.
+"""
+function constant_pauli_basis_n_qubits(n::Int)
+    if n == 1
+        return pauli_basis
+    else
+        # Compute the Kronecker product iteratively for n qubits
+        basis = pauli_basis
+        for _ in 2:n
+            basis = [kron(p1, p2) for p1 in basis, p2 in pauli_basis]
+        end
+        return basis
+    end
+end
+
+"""
+    function get_unitary_dagmat(gate::TUnitary, params)
+
+Compute the conjugate transpose of the unitary matrix for the T gate.
+
+Arguments
+- `gate::TUnitary`: The T gate.
+- `params::Vector{Float64}`: The parameters for the gate.
+
+Returns
+- `U::Array{ComplexF64}`: The conjugate transpose of the unitary matrix.
+"""
+function get_unitary_dagmat(gate::TUnitary, params=[])
+
+    U = [[1 0]; [0 exp(1.0im * pi / 4)]]
+
+    return U'
+end
+
+"""
+    function get_unitary_dagmat(gate::PauliRotation, params)
+
+Compute the conjugate transpose of the unitary matrix for the PauliRotation gate.
+
+Arguments
+- `gate::PauliRotation`: The PauliRotation gate.
+- `params::Vector{Float64}`: A length-1 parameter for the gate.
+
+Returns 
+- `U::Array{ComplexF64}`: The conjugate transpose of the unitary matrix.
+"""    
+function get_unitary_dagmat(gate::PauliRotation, params)
+
+    theta = params[1]
+    nqubits = length(gate.qinds)
+    pauli_basis_vec = constant_pauli_basis_n_qubits(nqubits)
+
+    # The indices of the pauli matrix are sorted in ascending order
+    sorted_indices = sortperm(gate.qinds)
+    pauli = gate.symbols[sorted_indices]
+
+    # These pauli matrices are normalized by sqrt(2)^nqubits
+    pauli_mat = sqrt(2)^nqubits * pauli_basis_vec[symboltoint(pauli) + 1]
+
+    id = Matrix(1.0I, 2^nqubits, 2^nqubits)
+
+    U = cos(theta/2) * id - 1.0im * sin(theta/2) * pauli_mat
+
+    return U'
+end
+
+"""
+    function get_unitary_dagmat(gate::U1Unitary, params)
+
+Compute the conjugate transpose of the unitary matrix for the U1 gate.
+
+The 4x4 unitary is of the form:
+U = [[exp(iφ1) 0 0 0];
+     [0 exp(-0.5im * (α + β - 2δ)) * cos(θ/2) exp(0.5im * (α - β + 2δ)) * sin(θ/2) 0];
+     [0 - exp( - 0.5im * (α - β - 2δ)) * sin(θ/2) exp(0.5im * (α + β + 2δ)) * cos(θ/2) 0];
+     [0 0 0 exp(iφ2)]]
+
+Arguments
+- `gate::U1Unitary`: The U1 gate.
+- `params::Vector{Float64}`: The parameters for the gate.
+    Order of the parameters are [θ, α, β, δ, φ1, φ2].
+
+Returns
+- `U::Array{ComplexF64}`: The conjugate transpose of the unitary matrix.
+"""
+function get_unitary_dagmat(gate::U1Unitary, params)
+
+    nqubits = length(gate.qinds)
+    all_params = zeros(Float64, gate.nparams)
+    all_params[1:length(params)] = params
+    θ, α, β, δ, φ1, φ2 = all_params
+
+    U = zeros(ComplexF64, 2^nqubits, 2^nqubits)
+
+    # Add checks for the number of qubits
+    U[1, 1] = exp(1.0im * φ1)
+    U[4, 4] = exp(1.0im * φ2)
+    U[2, 2] = exp(-0.5im * (α + β - 2δ)) * cos(θ/2)
+    U[2, 3] = exp(0.5im * (α - β + 2δ)) * sin(θ/2)
+    U[3, 2] = - exp( - 0.5im * (α - β - 2δ)) * sin(θ/2)
+    U[3, 3] = exp(0.5im * (α + β + 2δ)) * cos(θ/2)
+
+    return U'
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,10 @@ using Random
 
     include("test_paulioperations.jl")
 
+    include("test_paulitransfermaps.jl")    
+
+    include("test_unitaries.jl")    
+
     include("test_truncations.jl")
 
     include("test_numericalcertificates.jl")

--- a/test/test_paulitransfermaps.jl
+++ b/test/test_paulitransfermaps.jl
@@ -1,0 +1,120 @@
+using LinearAlgebra
+using Random
+using Test
+
+@testset "Unitaries PTM Tests" begin
+    """Test the PTM for unitary matrices."""
+    tol=1e-12
+
+    # Test using single-qubit PauliRotation gate
+    @testset "PauliRotation Y" begin
+        pauligate = PauliRotation([:Y], [ 0])
+        theta = Random.rand()
+
+        udag = get_unitary_dagmat(pauligate, [theta])
+
+        ptmmap = calc_ptm_dagmap(udag)
+
+        expected_ptm = [
+            [1 0 0 0];
+            [0 cos(theta) 0 -sin(theta)];
+            [0 0 1 0];
+            [0 sin(theta) 0 cos(theta)]
+        ]
+       
+       @test LinearAlgebra.norm(ptmmap - expected_ptm) < tol
+    end
+
+    # Test using T gate
+    @testset "TUnitary" begin
+        tgate = TUnitary([1])
+        udag = get_unitary_dagmat(tgate, [])
+
+        ptmmap = calc_ptm_dagmap(udag)
+
+        expected_ptm = [
+            [1 0 0 0];
+            [0 1/sqrt(2) 1/sqrt(2) 0];
+            [0 -1/sqrt(2) 1/sqrt(2) 0];
+            [0 0 0 1]
+        ]
+
+        @test LinearAlgebra.norm(ptmmap - expected_ptm) < tol
+    end
+
+    #TODO (YT): add tests for two-qubit PauliRotation gates using QuEst.
+end
+
+@testset "PauliRotations PTM" begin
+
+    function get_expected_ptm(nqubits, gate, param)
+        """Construct the expected PTM from the PauliPropagation."""
+        ptm_map_expected = Vector{Dict}()
+        for i in 0:4^nqubits-1
+            
+            pstr = PauliString(nqubits, i, 1.)
+            p_propagated = propagate([gate], pstr, [param]).terms
+
+            push!(ptm_map_expected, p_propagated)
+        end
+
+        return ptm_map_expected
+
+    end
+
+    function get_ptm_map_dict(gate, theta, type)
+        """Get the PTM map as a dictionary."""
+
+        udag = get_unitary_dagmat(gate, [theta])
+        ptm_mat = calc_ptm_dagmap(udag)
+        ptm_map = get_ptm_sparse(ptm_mat, type)
+
+        return [Dict(t[i] => t[i+1] for i in 1:2:length(t)) for t in ptm_map]
+    end
+
+    function is_ptm_expected(ptm_map_dict, ptm_map_expected)
+        """Check if the PTM is consistent with the PauliPropagation."""
+
+        for (t_actual, t_expected) in zip(ptm_map_dict, ptm_map_expected)
+
+            # Check if the keys are the same
+            @assert keys(t_actual) == keys(t_expected)
+
+            for (k, v) in t_actual
+                # Check the ptm map is the same
+                @assert isapprox(v, t_expected[k])
+            end
+        end
+
+        return true
+    end    
+
+    @testset "Single qubit rotation" begin
+        nqubits = 1
+        pauligate = PauliRotation([:Y], [1])
+        theta = Random.rand() * 2 * pi
+
+        ptm_map_dict = get_ptm_map_dict(pauligate, theta, getinttype(nqubits))
+
+        # PauliPropagation
+        ptm_map_expected = get_expected_ptm(nqubits, pauligate, theta)
+
+        # Check if the PTM is consistent with the PauliPropagation
+        @test is_ptm_expected(ptm_map_dict, ptm_map_expected)
+    end
+
+    @testset "Two qubit rotation" begin
+        nqubits = 2
+        pauligate = PauliRotation([:Y, :X], [1, 2])
+        theta = Random.rand() * 2 * pi
+
+        ptm_map_dict = get_ptm_map_dict(pauligate, theta, getinttype(nqubits))
+
+        # PauliPropagation
+        ptm_map_expected = get_expected_ptm(nqubits, pauligate, theta)
+
+        # Check if the PTM is consistent with the PauliPropagation
+        @test is_ptm_expected(ptm_map_dict, ptm_map_expected)
+    end
+    
+end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -1,0 +1,61 @@
+using LinearAlgebra
+using Random
+using Test
+
+tol=1e-10
+
+@testset "Pauli basis" begin
+    """Test recursive generation of Pauli basis for 1 and 2 qubits"""
+    nqubits = 1
+    @test constant_pauli_basis_n_qubits(nqubits) == pauli_basis
+
+    nqubits = 2
+    pauli_basis_two_qubit = [
+        kron(p1, p2) for p1 in pauli_basis, p2 in pauli_basis
+    ]
+    @test constant_pauli_basis_n_qubits(nqubits) == pauli_basis_two_qubit
+    
+end
+
+@testset "U1 unitary two-qubit" begin
+    
+    gate = U1Unitary(6, [0, 1])
+    params = [0.1, 0.2, 0.3, 0.4, 0., 0.]
+    expected_U = [
+        [1 0 0 0 ]; 
+        [0 0.9875353715596337 + 0.1492513737209447im 0.04694906782365546 + 0.01713774756136047im 0 ]; 
+        [0 -0.045003598147776255 - 0.021739216056256186im 0.7950889010970834 + 0.6044300803163632im 0 ]; 
+        [0 0 0 1]
+    ]  # this is the expected unitary matrix for the given parameters (QuEst)
+    U = get_unitary_dagmat(gate, params)'
+    
+    @test LinearAlgebra.norm(U - expected_U) < tol
+end
+
+@testset "PauliRotation two-qubit" begin
+    # test Pauli rotation daggered unitary
+    pauligate = PauliRotation([:I, :X], [1, 3])
+    theta = Random.rand()
+    Rxdag = get_unitary_dagmat(pauligate, [theta])
+    
+    expected_Rxdag = [
+        [cos(theta/2) 1im * sin(theta/2) 0 0];
+        [1im * sin(theta/2) cos(theta/2) 0 0];
+        [0 0 cos(theta/2) 1im * sin(theta/2)];
+        [0 0 1im * sin(theta/2) cos(theta/2)]
+    ]
+    @test LinearAlgebra.norm(Rxdag - expected_Rxdag) < tol
+end
+
+@testset "T gate" begin
+    # test T unitary
+    tgate = TUnitary([1])
+    UT = get_unitary_dagmat(tgate, [])
+    expected_UT = [
+        [1 0];
+        [0 exp(-1.0im * pi / 4)]
+    ]
+    @test LinearAlgebra.norm(UT - expected_UT) < tol
+end
+
+


### PR DESCRIPTION
# Feature Addition: Pauli Transfer Matrix from Unitary

## Summary

This PR implements the computation of the Pauli transfer matrix (PTM) given a unitary matrix.

## Rationale

Now the user will be able to define an arbitrary unitary and compute the associated PTM as sparse maps. This allows pauli propagation with gates that are not natively Pauli gates. 

## Design

We include an additional subfolder `PauliTransferMatrix`. This contains 
 - `unitaries.jl`: defines an arbitrary parameterized unitary. 
     Note that `params` argument now allows multi-dimensional parameters to parameterize the same unitary. This is a generalization compared to a PauliRotation with a scalar parameter `params=[theta]`.
 - `paulitransfermaps.jl`: compute the PTM using `get_ptm_sparse` in the format aligned with existing standard.

## Testing

- `unitaries.jl`: tested using single-qubit T-gate, two-qubit U(1)-symmetric unitary and two-qubit PauliRotations
- `paulitransfermaps.jl`: tested single-qubit PTMs with PauliRotation and T-gate verified using QuEst; tested two-qubit PTM using existing implementations in `PauliRotations`.


## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

