### PR TITLE
v0.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PauliPropagation"
 uuid = "293282d5-3c99-4fb6-92d0-fd3280a19750"
 authors = ["Manuel S. Rudolph"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/Circuits/builders.jl
+++ b/src/Circuits/builders.jl
@@ -258,14 +258,14 @@ rxlayer!(circuit, nqubits) = append!(circuit, (PauliRotation(:X, ii) for ii in 1
 
 Append a layer of single-qubit `PauliRotation(:Y, qind)` gates to the circuit for each pair in the topology.
 """
-rylayer!(circuit, nqubits) = append!(circuit, (PauliRotation(:y, ii) for ii in 1:nqubits))
+rylayer!(circuit, nqubits) = append!(circuit, (PauliRotation(:Y, ii) for ii in 1:nqubits))
 
 """
     rzlayer!(circuit, nqubits)
 
 Append a layer of single-qubit `PauliRotation(:Z, qind)` gates to the circuit for each pair in the topology.
 """
-rzlayer!(circuit, nqubits) = append!(circuit, (PauliRotation(:Y, ii) for ii in 1:nqubits))
+rzlayer!(circuit, nqubits) = append!(circuit, (PauliRotation(:Z, ii) for ii in 1:nqubits))
 
 """
     rxxlayer!(circuit, topology)

--- a/src/Circuits/utils.jl
+++ b/src/Circuits/utils.jl
@@ -28,9 +28,9 @@ function getparameterindices(circuit, ::Type{GT}) where {GT<:ParametrizedGate}
     indices = Int[]
 
     param_idx = 1
-    for (ii, gate) in enumerate(circuit)
+    for gate in circuit
         if isa(gate, GT)
-            push!(indices, ii)
+            push!(indices, param_idx)
         end
         if isa(gate, ParametrizedGate)
             param_idx += 1
@@ -49,9 +49,9 @@ function getparameterindices(circuit, ::Type{PauliRotation}, gate_symbols::Vecto
     indices = Int[]
 
     param_idx = 1
-    for (ii, gate) in enumerate(circuit)
+    for gate in circuit
         if isa(gate, PauliRotation) && gate.symbols == gate_symbols
-            push!(indices, ii)
+            push!(indices, param_idx)
         end
         if isa(gate, ParametrizedGate)
             param_idx += 1
@@ -70,9 +70,9 @@ function getparameterindices(circuit, ::Type{PauliRotation}, gate_symbols::Vecto
     indices = Int[]
 
     param_idx = 1
-    for (ii, gate) in enumerate(circuit)
+    for gate in circuit
         if isa(gate, PauliRotation) && gate.symbols == gate_symbols && gate.qinds == qinds
-            push!(indices, ii)
+            push!(indices, param_idx)
         end
         if isa(gate, ParametrizedGate)
             param_idx += 1


### PR DESCRIPTION
[bugfixes]: 
- `rylayer!()` and `rzlayer!()` would append invalid or the wrong kind of `PauliRotation` gates
- `getparameterindices()` would incorrectly return gate positions instead of parameter positions when circuit contains non-parametrized gates.