### PR TITLE
Simplify specializations

### DIFF
--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -136,38 +136,23 @@ function applytoall!(gate::PauliNoise, p, psum, aux_psum; kwargs...)
 
     # loop over all Pauli strings and their coefficients in the Pauli sum
     for (pstr, coeff) in psum
-        if getpauli(pstr, gate.qind) == 0
-            # Pauli is I, so the gate does not do anything
+
+        # the Pauli on the site that the noise acts on
+        pauli = getpauli(pstr, gate.qind)
+
+        # `isdamped` is defined in noisechannels.jl for each Pauli noise channel
+        # I Paulis are never damped, but the others vary
+        if !isdamped(gate, pauli)
             continue
         end
 
-        # apply the Pauli noise, which will reduce the coefficient
-        pstr, new_coeff = apply(gate, pstr, coeff, p; kwargs...)
-
-        # set the coefficient of the Pauli string in the psum to the new coefficient
+        new_coeff = coeff * (1 - p)
+        # change the coefficient in psum, don't move anything to aux_psum
         set!(psum, pstr, new_coeff)
     end
 
     return
 end
-
-
-"""
-    apply(gate::PauliNoise, pstr::PauliStringType, coeff, p)
-
-Apply a `PauliNoise` channel to an integer Pauli string `pstr` with noise strength `p`.
-Physically `p` is restricted to the range `[0, 1]` and updates the coefficient `coeff` via `coeff*(1-p)` if damped.
-"""
-function apply(gate::PauliNoise, pstr::PauliStringType, coeff, p; kwargs...)
-    pauli = getpauli(pstr, gate.qind)
-
-    if isdamped(gate, pauli) # this function is defined in the noisechannels.jl file for each Pauli noise channel
-        coeff *= (1 - p)
-    end
-
-    return pstr, coeff
-end
-
 
 ### Amplitude Damping Noise
 """
@@ -177,7 +162,7 @@ Overload of `applytoall!` for `AmplitudeDampingNoise` gates.
 It fixes the type-instability of the apply() function and reduces moving Pauli strings between psum and aux_psum.
 `psum` and `aux_psum` are merged later.
 """
-function applytoall!(gate::AmplitudeDampingNoise, theta, psum, aux_psum; kwargs...)
+function applytoall!(gate::AmplitudeDampingNoise, gamma, psum, aux_psum; kwargs...)
 
     # loop over all Pauli strings and their coefficients in the Pauli sum
     for (pstr, coeff) in psum
@@ -185,16 +170,20 @@ function applytoall!(gate::AmplitudeDampingNoise, theta, psum, aux_psum; kwargs.
         if pauli == 0
             # Pauli is I, so the gate does not do anything
             continue
+
         elseif pauli == 1 || pauli == 2
             # Pauli is X or Y, so the gate will give a sqrt(1-gamma) prefactor
-            pstr, new_coeff = diagonalapply(gate, pstr, coeff, theta; kwargs...)
+            new_coeff = sqrt(1 - gamma)
             # set the coefficient of the Pauli string in the psum to the new coefficient
             set!(psum, pstr, new_coeff)
+
         else
             # Pauli is Z, so the gate will split the Pauli string 
 
             # else we know the gate will split th Pauli string into two
-            pstr, coeff1, new_pstr, coeff2 = splitapply(gate, pstr, coeff, theta; kwargs...)
+            new_pstr = setpauli(pstr, 0, gate.qind)
+            coeff1 = (1 - gamma) * coeff
+            coeff2 = gamma * coeff
 
             # set the coefficient of the original Pauli string
             set!(psum, pstr, coeff1)
@@ -206,50 +195,6 @@ function applytoall!(gate::AmplitudeDampingNoise, theta, psum, aux_psum; kwargs.
     end
 
     return
-end
-
-"""
-    actsdiagonally(gate::AmplitudeDampingNoise, pstr::PauliStringType)
-
-Check if the amplitude damping noise channel acts diagonally on the Pauli string `pstr`.
-This implies no splitting (acting diagonally) which happens when acting on I, X, and Y.
-"""
-function actsdiagonally(gate::AmplitudeDampingNoise, pstr::PauliStringType; kwargs...)
-    return getpauli(pstr, gate.qind) != 3
-end
-
-"""
-    diagonalapply(gate::AmplitudeDampingNoise, pstr::PauliStringType, coeff, gamma)
-
-Apply an amplitude damping noise channel to an integer Pauli string `pstr` with noise strength `gamma`.
-This is under the assumption that it has been checked that the noise channel acts diagonally on the Pauli string.
-Returns a tuple of Pauli string and coefficient.
-Physically `gamma` is restricted to the range `[0, 1]`.
-A coefficient of the Pauli string can optionally be passed as `coefficient`.
-"""
-function diagonalapply(gate::AmplitudeDampingNoise, pstr::PauliStringType, coeff, gamma; kwargs...)
-
-    local_pauli = getpauli(pstr, gate.qind)
-
-    if local_pauli != 0  # non-identity Pauli
-        coeff *= sqrt(1 - gamma)
-    end
-
-    return pstr, coeff
-end
-
-"""
-    splitapply(gate::AmplitudeDampingNoise, pstr::PauliStringType, coeff, gamma)
-
-Apply an amplitude damping noise channel to an integer Pauli string `pstr` with noise strength `gamma`.
-This is under the assumption that it has been checked that the noise channel acts on a Z Pauli and splits.
-Returns a tuple of two pairs of Pauli strings and coefficients.
-Physically `gamma` is restricted to the range `[0, 1]`.
-A coefficient of the Pauli string can optionally be passed as `coefficient`.
-"""
-function splitapply(gate::AmplitudeDampingNoise, pstr::PauliStringType, coeff, gamma; kwargs...)
-    new_pstr = setpauli(pstr, 0, gate.qind)
-    return pstr, (1 - gamma) * coeff, new_pstr, gamma * coeff
 end
 
 ## T Gate

--- a/src/Surrogate/propagate.jl
+++ b/src/Surrogate/propagate.jl
@@ -142,6 +142,32 @@ end
 
 ## For Clifford Gates
 
+"""
+    apply(gate::CliffordGate, pstr::PauliStringType, coeff::NodePathProperties)
+
+Apply a `CliffordGate` to an integer Pauli string and `NodePathProperties` coefficient. 
+"""
+function apply(gate::CliffordGate, pstr::PauliStringType, coeff::NodePathProperties; kwargs...)
+    # this array carries the new Paulis + sign for every occuring old Pauli combination
+    map_array = clifford_map[gate.symbol]
+
+    qinds = gate.qinds
+
+    # this integer carries the active Paulis on its bits
+    lookup_int = getpauli(pstr, qinds)
+
+    # this integer can be used to index into the array returning the new Paulis
+    # +1 because Julia is 1-indexed and lookup_int is 0-indexed
+    sign, partial_pstr = map_array[lookup_int+1]
+
+    # insert the bits of the new Pauli into the old Pauli
+    pstr = setpauli(pstr, partial_pstr, qinds)
+
+    coeff = _multiplysign(coeff, sign)
+
+    return pstr, coeff
+end
+
 function _multiplysign(pth::NodePathProperties, sign; kwargs...)
     return NodePathProperties(_multiplysign(pth.node, sign), pth.nsins, pth.ncos, pth.freq)
 end

--- a/src/Surrogate/propagate.jl
+++ b/src/Surrogate/propagate.jl
@@ -66,6 +66,39 @@ end
 
 
 ## For Pauli Rotations
+"""
+    applytoall!(gate::PauliRotation, theta, psum, aux_psum; kwargs...)
+
+Overload of `applytoall!` for `PauliRotation` gates. 
+It fixes the type-instability of the `apply()` function and reduces moving Pauli strings between `psum` and `aux_psum`.
+`psum` and `aux_psum` are merged later.
+"""
+function applytoall!(gate::PauliRotation, theta, psum::PauliSum{TT,NodePathProperties}, aux_psum; kwargs...) where {TT<:PauliStringType}
+    # turn the (potentially) PauliRotation gate into a MaskedPauliRotation gate
+    # this allows for faster operations
+    gate = _tomaskedpaulirotation(gate, paulitype(psum))
+
+    # loop over all Pauli strings and their coefficients in the Pauli sum
+    for (pstr, coeff) in psum
+
+        if commutes(gate, pstr)
+            # if the gate commutes with the pauli string, do nothing
+            continue
+        end
+
+        # else we know the gate will split th Pauli string into two
+        pstr, coeff1, new_pstr, coeff2 = splitapply(gate, pstr, coeff, theta; kwargs...)
+
+        # set the coefficient of the original Pauli string
+        set!(psum, pstr, coeff1)
+
+        # set the coefficient of the new Pauli string in the aux_psum
+        # we can set the coefficient because PauliRotations create non-overlapping new Pauli strings
+        set!(aux_psum, new_pstr, coeff2)
+    end
+
+    return
+end
 
 function splitapply(gate::MaskedPauliRotation, pstr::PauliStringType, coeff::NodePathProperties, theta; kwargs...)
     coeff1 = _applycos(coeff, theta; kwargs...)


### PR DESCRIPTION
- Specialized apply functions are significantly simpler to parse and work with. There should be less "wtfs per minute". This comes at the cost of the Surrogate duplicating more code, but it is legacy code that will not always remain in this package.

- `PauliRotation`s are now ~5-10% faster because we only compute `sin(theta)` and `cos(theta)` once per gate, instead of once per Pauli string.