### PR TITLE
Refactor apply() return type

### DIFF
--- a/examples/4-custom-gates.ipynb
+++ b/examples/4-custom-gates.ipynb
@@ -21,6 +21,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eadc57bc-b112-413e-9302-92a86aa0df96",
+   "metadata": {},
+   "source": [
+    "### A Gate that maps one Pauli string to one Pauli string"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84f3d8af-1fb2-46cc-8573-e835327acd38",
    "metadata": {},
    "source": [
@@ -44,8 +52,8 @@
    "id": "60d9de52-66f8-4b7a-8a12-f52570156556",
    "metadata": {},
    "source": [
-    "The action of a `SWAP` gate on a Pauli string is that it swaps the Paulis on two sites. We can now define a function `apply` which receives these 3 arguments in this order, as well as potential `kwargs`: `apply(gate::YourGate, pstr, coefficient; kwargs...)`. We can ignore `kwargs` for now, but you can use them to pass arguments from the top level down to your function. If your custom gate is parametrized, then you have you sub-type `ParametrizedGate` instead of `StaticGate`, and the `apply` function\n",
-    "will receive a fourth argument, which is the parameter: `apply(gate::YourGate, pstr, coefficient, theta; kwargs...)`."
+    "The action of a `SWAP` gate on a Pauli string is that it swaps the Paulis on two sites. We can now define a function `apply` which receives these 3 arguments in this order, as well as potential `kwargs`: `apply(gate::YourGate, pstr, coeff; kwargs...)`. We can ignore `kwargs` for now, but you can use them to pass arguments from the top level down to your function. If your custom gate is parametrized, then you have you sub-type `ParametrizedGate` instead of `StaticGate`, and the `apply` function\n",
+    "will receive a fourth argument, which is the parameter: `apply(gate::YourGate, pstr, coeff, theta; kwargs...)`."
    ]
   },
   {
@@ -63,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "function PauliPropagation.apply(gate::CustomSWAPGate, pstr, coefficient; kwargs...)\n",
+    "function PauliPropagation.apply(gate::CustomSWAPGate, pstr, coeff; kwargs...)\n",
     "    # get the Pauli on the first site\n",
     "    pauli1 = getpauli(pstr, gate.qinds[1])\n",
     "    # get the Pauli on the second site\n",
@@ -74,7 +82,8 @@
     "    # set the Pauli on the second site to the first Pauli\n",
     "    pstr = setpauli(pstr, pauli1, gate.qinds[2])\n",
     "\n",
-    "    return pstr, coefficient\n",
+    "    # apply() is always expected to return a tuple of (pstr, coeff) tuples\n",
+    "    return ((pstr, coeff),)\n",
     "end"
    ]
   },
@@ -83,7 +92,9 @@
    "id": "6dff040b-5a0e-4c77-af14-45daabba640b",
    "metadata": {},
    "source": [
-    "This is it, really."
+    "This is it, really.\n",
+    "\n",
+    "`apply()` is expected to always return a tuple of `(pstr, coeff)` tuples. Here, only one Pauli string and its coefficient are returned, so we need to create a tuple of length one via `((pstr, coeff),)`. Alternatively `tuple((pstr, coeff))` also works. We will see later what to do with gates that create new Pauli strings."
    ]
   },
   {
@@ -105,7 +116,7 @@
     "ny = 5\n",
     "nq = nx * ny\n",
     "\n",
-    "topology = get2dtopology(nx, ny);"
+    "topology = rectangletopology(nx, ny);"
    ]
   },
   {
@@ -281,7 +292,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.477635 seconds (479.11 k allocations: 31.450 MiB, 99.57% compilation time)\n"
+      "  0.642559 seconds (797.04 k allocations: 38.085 MiB, 1.34% gc time, 99.68% compilation time)\n"
      ]
     },
     {
@@ -289,25 +300,25 @@
       "text/plain": [
        "PauliSum(nqubits: 25, 576 Pauli terms:\n",
        " 0.0053683 * IIIIYZIIIXYIIIZIIIII...\n",
-       " -0.010561 * IIIIIYIIIXXYZIIIZIII...\n",
-       " -0.0065309 * IIIZXYIIIYYZIIIIIIII...\n",
        " -0.0069415 * ZIIZYXZIIZXXZIIIZIII...\n",
-       " 0.0082654 * IIIZXZIIIXXYZIZIZIII...\n",
        " 0.080065 * IIIZYIIIIIYIIIIIIIII...\n",
-       " -0.0056512 * IIIIZXIIIXXXZIZZXIII...\n",
-       " -0.0060663 * IIIIZZIIIIXYZIIXIIII...\n",
-       " -0.01727 * ZIIZXXIIIXZIIIZIIIII...\n",
        " -0.0085018 * IIIIIZIIIXYIIIIIIIII...\n",
-       " 0.0093524 * IIIIIXIIIYXXZIZZXIII...\n",
        " -0.03761 * IIIZXZIIIZZIIIIIIIII...\n",
-       " -0.01582 * IIIZYZIIIIYIIIIIIIII...\n",
-       " -0.0059443 * IIIZXXIIIZZXZIIIZIII...\n",
        " -0.0063894 * IIIZXIIIIZYYZIIIZIII...\n",
        " 0.022245 * IIIZYIIIIZYZIIIIIIII...\n",
-       " -0.024117 * IIIIIZIIIYXZIIZIIIII...\n",
-       " -0.0075649 * IIIIZZZIIXXXZIZZXIII...\n",
-       " -0.013565 * IIIZYIIIIZZZIIIIIIII...\n",
        " 0.0070561 * IIIZXXIIIXXXZIZIZIII...\n",
+       " 0.0071172 * IIIZYZIIIZYYZIIZZIII...\n",
+       " -0.00951 * IIIIIZZIIYXXZIZZYIII...\n",
+       " 0.007368 * IIIZXIIIIXYIIIZIIIII...\n",
+       " 0.093232 * IIIZXIIIIXXIIIZZIIII...\n",
+       " 0.016597 * IIIIZZIIIXYIIIZIIIII...\n",
+       " -0.0058598 * ZIIIIXIIIYXZIIZIIIII...\n",
+       " 0.0086098 * IIIIZIIIIXXIIIZZIIII...\n",
+       " 0.046612 * IIIZXIIIIZXIIIIZIIII...\n",
+       " 0.012269 * IIIZXZIIIZXIIIIIIIII...\n",
+       " 0.056603 * IIIIIZZIIYXXZIZIZIII...\n",
+       " -0.029879 * IIIIZXZIIIZZIIIIIIII...\n",
+       " 0.015797 * ZIIIIYIIIYXXZIZIZIII...\n",
        "  ⋮)"
       ]
      },
@@ -325,7 +336,7 @@
    "id": "b7eae7d4-4f1b-4524-8d4e-e6823130de9b",
    "metadata": {},
    "source": [
-    "Overlap with the zero-state"
+    "Overlap with the zero-state:"
    ]
   },
   {
@@ -337,7 +348,7 @@
     {
      "data": {
       "text/plain": [
-       "-0.7211301948203008"
+       "-0.7211301948203009"
       ]
      },
      "execution_count": 12,
@@ -383,7 +394,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.071685 seconds (63.76 k allocations: 4.651 MiB, 97.44% compilation time)\n"
+      "  0.085717 seconds (99.14 k allocations: 4.924 MiB, 97.66% compilation time)\n"
      ]
     }
    ],
@@ -408,7 +419,7 @@
     {
      "data": {
       "text/plain": [
-       "-0.7211301948203008"
+       "-0.7211301948203009"
       ]
      },
      "execution_count": 15,
@@ -477,7 +488,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  1.628 ms (1081 allocations: 471.59 KiB)\n"
+      "  1.713 ms (1030 allocations: 158.00 KiB)\n"
      ]
     }
    ],
@@ -495,7 +506,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  1.690 ms (1081 allocations: 471.59 KiB)\n"
+      "  1.816 ms (1030 allocations: 158.00 KiB)\n"
      ]
     }
    ],
@@ -521,8 +532,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MethodInstance for PauliPropagation.apply(::CustomSWAPGate, ::UInt64, ::Float64, ::Float64)\n",
-      "  from apply(\u001b[90mgate\u001b[39m::\u001b[1mSG\u001b[22m, \u001b[90mpstr\u001b[39m, \u001b[90mcoeff\u001b[39m, \u001b[90mtheta\u001b[39m; kwargs...) where SG<:StaticGate\u001b[90m @\u001b[39m \u001b[90mPauliPropagation\u001b[39m \u001b[90m~/.julia/dev/PauliPropagation/src/Propagation/\u001b[39m\u001b[90m\u001b[4mgenerics.jl:164\u001b[24m\u001b[39m\n",
+      "MethodInstance for apply(::CustomSWAPGate, ::UInt64, ::Float64, ::Float64)\n",
+      "  from apply(\u001b[90mgate\u001b[39m::\u001b[1mSG\u001b[22m, \u001b[90mpstr\u001b[39m, \u001b[90mcoeff\u001b[39m, \u001b[90mtheta\u001b[39m; kwargs...) where SG<:StaticGate\u001b[90m @\u001b[39m \u001b[90mPauliPropagation\u001b[39m \u001b[90m~/.julia/dev/PauliPropagation/src/Propagation/\u001b[39m\u001b[90m\u001b[4mgenerics.jl:167\u001b[24m\u001b[39m\n",
       "Static Parameters\n",
       "  SG = \u001b[36mCustomSWAPGate\u001b[39m\n",
       "Arguments\n",
@@ -531,11 +542,12 @@
       "  pstr\u001b[36m::UInt64\u001b[39m\n",
       "  coeff\u001b[36m::Float64\u001b[39m\n",
       "  theta\u001b[36m::Float64\u001b[39m\n",
-      "Body\u001b[36m::Tuple{UInt64, Float64}\u001b[39m\n",
-      "\u001b[90m1 ─\u001b[39m %1 = Core.NamedTuple()\u001b[36m::Core.Const(NamedTuple())\u001b[39m\n",
-      "\u001b[90m│  \u001b[39m %2 = Base.pairs(%1)\u001b[36m::Core.Const(Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}())\u001b[39m\n",
-      "\u001b[90m│  \u001b[39m %3 = PauliPropagation.:(var\"#apply#89\")(%2, #self#, gate, pstr, coeff, theta)\u001b[36m::Tuple{UInt64, Float64}\u001b[39m\n",
-      "\u001b[90m└──\u001b[39m      return %3\n",
+      "Body\u001b[36m::Tuple{Tuple{UInt64, Float64}}\u001b[39m\n",
+      "\u001b[90m1 ─\u001b[39m %1 = PauliPropagation.:(var\"#apply#82\")\u001b[36m::Core.Const(PauliPropagation.var\"#apply#82\")\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %2 = Core.NamedTuple()\u001b[36m::Core.Const(NamedTuple())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %3 = Base.pairs(%2)\u001b[36m::Core.Const(Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %4 = (%1)(%3, #self#, gate, pstr, coeff, theta)\u001b[36m::Tuple{Tuple{UInt64, Float64}}\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m      return %4\n",
       "\n"
      ]
     }
@@ -550,6 +562,14 @@
    "metadata": {},
    "source": [
     "All blue means that everything is great! If correctly implemented, `apply` will be type stable if it returns a known number of Pauli and coefficient pairs. Here it is just 1 because it is a Clifford gate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3bd4f88-e472-4fe9-8f8e-5c91266e1e02",
+   "metadata": {},
+   "source": [
+    "### A gate that branches into more than one Pauli string"
    ]
   },
   {
@@ -577,7 +597,7 @@
    "id": "1ab4607c-13fa-4097-85ed-ecc6f1b506ad",
    "metadata": {},
    "source": [
-    "A `T` gate is a non-Clifford gate that commutes with `I` and `Z`, splits `X` into `cos(π/4)X - sin(π/4)Y`, and `Y` into `cos(π/4)Y + sin(π/4)X`. \n",
+    "A `T` gate is a non-Clifford gate that commutes with `I` and `Z`, splits `X` into `cos(π/4)X - sin(π/4)Y`, and `Y` into `cos(π/4)Y + sin(π/4)X` (in the Heisenberg picture). \n",
     "\n",
     "Let's write the code for that."
    ]
@@ -589,12 +609,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "function PauliPropagation.apply(gate::CustomTGate, pstr, coefficient; kwargs...)\n",
+    "function PauliPropagation.apply(gate::CustomTGate, pstr, coeff; kwargs...)\n",
     "    # get the Pauli on the site `gate.qind`\n",
     "    pauli = getpauli(pstr, gate.qind)\n",
     "    \n",
     "    if pauli == 0 || pauli == 3  # I or Z commute\n",
-    "        return pstr, coefficient     \n",
+    "        # return a tuple of one (pstr, coeff) tuple\n",
+    "        return ((pstr, coeff),)     \n",
     "    end\n",
     "    \n",
     "    if pauli == 1 # X goes to X, -Y\n",
@@ -602,19 +623,20 @@
     "        # set the Pauli\n",
     "        new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
     "        # adapt the coefficients\n",
-    "        new_coefficient = -1 * coefficient * sin(π/4)\n",
-    "        coefficient_prime = coefficient * cos(π/4)\n",
+    "        new_coeff = -1 * coeff * sin(π/4)\n",
     "        \n",
     "    else # Y goes to Y, X\n",
     "        new_pauli = 1  # X\n",
     "        # set the Pauli\n",
     "        new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
     "        # adapt the coefficients\n",
-    "        new_coefficient = coefficient * sin(π/4)\n",
-    "        coefficient_prime = coefficient * cos(π/4)\n",
+    "        new_coeff = coeff * sin(π/4)\n",
     "    end\n",
-    "    \n",
-    "    return pstr, coefficient_prime, new_pstr, new_coefficient\n",
+    "\n",
+    "    updated_coeff = coeff * cos(π/4)\n",
+    "\n",
+    "    # return a tuple of two (pstr, coeff) tuples\n",
+    "    return ((pstr, updated_coeff), (new_pstr, new_coeff))\n",
     "    \n",
     "end"
    ]
@@ -661,21 +683,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.064375 seconds (168.62 k allocations: 8.361 MiB, 87.55% compilation time)\n"
+      "  0.067614 seconds (72.29 k allocations: 3.653 MiB, 90.13% compilation time)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "PauliSum(nqubits: 25, 1702 Pauli terms:\n",
-       " 0.0058949 * IZIIIYXYIIIZXIIIIZII...\n",
-       " 0.013378 * IIIIIIYIIIIZXIIIIZII...\n",
+       " 0.014863 * IIIIIIZZIIIIXZIIIXZI...\n",
        " -0.032827 * IZIIIZYZIIIZYZIIIZII...\n",
        " 0.0058029 * IZZIIIIYIIIZXZIIIZII...\n",
        " 0.0054978 * IZIIIYXZIIIXXIIIZZII...\n",
-       " -0.01082 * IIIIIZXIIIIZYZIIIYZI...\n",
-       " -0.0066769 * IZIIIYXIIIIZXIIIIYZI...\n",
-       " -0.024172 * IIIIIZXIIIIYIIIIZZII...\n",
        " -0.014213 * IIIIIIXIZIIZYYIIIYII...\n",
        " -0.0073527 * IIIIIIIIZIIYXYIIZXII...\n",
        " 0.0075631 * IIIIIIIIIIIXXZIIIYZI...\n",
@@ -683,11 +701,15 @@
        " -0.053549 * IIIIIZXZIIIZXZIIIZII...\n",
        " 0.01401 * IZIIIYXYIIIZYZIIIZII...\n",
        " 0.0097479 * IIIIIIXIZIIIXYIIIZZI...\n",
-       " -0.02131 * IIIIIIYIIIIYXZIIIZII...\n",
        " 0.019155 * IIIIIIXIIIIZXZIIIXZI...\n",
-       " -0.0095632 * IIIIIIZZZIIXXXZIZZZI...\n",
-       " 0.015053 * IIIIIIYIZIIXXYIIZYII...\n",
-       " 0.0063405 * IIIIIIYIIIIYIIIIZYZI...\n",
+       " 0.011572 * IIIIIIYZZIIXXXZIZZZI...\n",
+       " 0.0090639 * IIIIIZXIIIIYZIIIZYII...\n",
+       " -0.0069645 * IZIIIXIZIIIZYIIIIZII...\n",
+       " 0.0061054 * IIIIIXIIIIIIZIIIIIII...\n",
+       " 0.031437 * IZIIIZYIIIIIXZIIIZII...\n",
+       " -0.0056792 * IIIIIIZZZIIXYYIIZYII...\n",
+       " 0.005949 * IZIIIIYZIIIXXZIIZYZI...\n",
+       " -0.0075995 * IIIIIIYZIIIIYIIIIYZI...\n",
        "  ⋮)"
       ]
      },
@@ -709,7 +731,7 @@
     {
      "data": {
       "text/plain": [
-       "0.3326289935884039"
+       "0.33262899358840403"
       ]
      },
      "execution_count": 25,
@@ -736,12 +758,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frozenZ_circuit = deepcopy(base_circuit);\n",
+    "libraryT_circuit = deepcopy(base_circuit);\n",
     "for qind in 1:nq\n",
-    "    insert!(frozenZ_circuit, 2*nparams_per_layer, TGate(qind))\n",
+    "    insert!(libraryT_circuit, 2*nparams_per_layer, TGate(qind))\n",
     "end\n",
     "for qind in 1:nq\n",
-    "    insert!(frozenZ_circuit, nparams_per_layer, TGate(qind))\n",
+    "    insert!(libraryT_circuit, nparams_per_layer, TGate(qind))\n",
     "end"
    ]
   },
@@ -765,12 +787,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.022177 seconds (11.34 k allocations: 2.497 MiB, 29.16% gc time, 42.21% compilation time)\n"
+      "  0.023013 seconds (16.78 k allocations: 1.075 MiB, 70.10% compilation time)\n"
      ]
     }
    ],
    "source": [
-    "@time frozenZ_psum = propagate(frozenZ_circuit, pstr, thetas; min_abs_coeff=min_abs_coeff);"
+    "@time libraryT_psum = propagate(libraryT_circuit, pstr, thetas; min_abs_coeff=min_abs_coeff);"
    ]
   },
   {
@@ -782,7 +804,7 @@
     {
      "data": {
       "text/plain": [
-       "0.3326289935884039"
+       "0.33262899358840403"
       ]
      },
      "execution_count": 28,
@@ -791,7 +813,7 @@
     }
    ],
    "source": [
-    "overlapwithzero(frozenZ_psum)"
+    "overlapwithzero(libraryT_psum)"
    ]
   },
   {
@@ -812,7 +834,7 @@
     }
    ],
    "source": [
-    "frozenZ_psum == ourT_psum"
+    "libraryT_psum == ourT_psum"
    ]
   },
   {
@@ -843,7 +865,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  7.675 ms (104334 allocations: 4.13 MiB)\n"
+      "  6.471 ms (1045 allocations: 273.09 KiB)\n"
      ]
     }
    ],
@@ -861,12 +883,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  6.075 ms (1158 allocations: 1.79 MiB)\n"
+      "  6.505 ms (1250 allocations: 326.22 KiB)\n"
      ]
     }
    ],
    "source": [
-    "@btime propagate($frozenZ_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
+    "@btime propagate($libraryT_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
    ]
   },
   {
@@ -887,18 +909,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MethodInstance for PauliPropagation.apply(::CustomTGate, ::UInt64, ::Float64)\n",
-      "  from apply(\u001b[90mgate\u001b[39m::\u001b[1mCustomTGate\u001b[22m, \u001b[90mpstr\u001b[39m, \u001b[90mcoefficient\u001b[39m; kwargs...)\u001b[90m @\u001b[39m \u001b[90mMain\u001b[39m \u001b[90m\u001b[4mIn[22]:1\u001b[24m\u001b[39m\n",
+      "MethodInstance for apply(::CustomTGate, ::UInt64, ::Float64)\n",
+      "  from apply(\u001b[90mgate\u001b[39m::\u001b[1mCustomTGate\u001b[22m, \u001b[90mpstr\u001b[39m, \u001b[90mcoeff\u001b[39m; kwargs...)\u001b[90m @\u001b[39m \u001b[90mMain\u001b[39m \u001b[90m\u001b[4mIn[22]:1\u001b[24m\u001b[39m\n",
       "Arguments\n",
       "  #self#\u001b[36m::Core.Const(PauliPropagation.apply)\u001b[39m\n",
       "  gate\u001b[36m::CustomTGate\u001b[39m\n",
       "  pstr\u001b[36m::UInt64\u001b[39m\n",
-      "  coefficient\u001b[36m::Float64\u001b[39m\n",
-      "Body\u001b[33m\u001b[1m::Union{Tuple{UInt64, Float64}, Tuple{UInt64, Float64, UInt64, Float64}}\u001b[22m\u001b[39m\n",
-      "\u001b[90m1 ─\u001b[39m %1 = Core.NamedTuple()\u001b[36m::Core.Const(NamedTuple())\u001b[39m\n",
-      "\u001b[90m│  \u001b[39m %2 = Base.pairs(%1)\u001b[36m::Core.Const(Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}())\u001b[39m\n",
-      "\u001b[90m│  \u001b[39m %3 = Main.:(var\"#apply#2\")(%2, #self#, gate, pstr, coefficient)\u001b[33m\u001b[1m::Union{Tuple{UInt64, Float64}, Tuple{UInt64, Float64, UInt64, Float64}}\u001b[22m\u001b[39m\n",
-      "\u001b[90m└──\u001b[39m      return %3\n",
+      "  coeff\u001b[36m::Float64\u001b[39m\n",
+      "Body\u001b[33m\u001b[1m::Union{Tuple{Tuple{UInt64, Float64}}, Tuple{Tuple{UInt64, Float64}, Tuple{UInt64, Float64}}}\u001b[22m\u001b[39m\n",
+      "\u001b[90m1 ─\u001b[39m %1 = Main.:(var\"#apply#2\")\u001b[36m::Core.Const(Main.var\"#apply#2\")\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %2 = Core.NamedTuple()\u001b[36m::Core.Const(NamedTuple())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %3 = Base.pairs(%2)\u001b[36m::Core.Const(Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}())\u001b[39m\n",
+      "\u001b[90m│  \u001b[39m %4 = (%1)(%3, #self#, gate, pstr, coeff)\u001b[33m\u001b[1m::Union{Tuple{Tuple{UInt64, Float64}}, Tuple{Tuple{UInt64, Float64}, Tuple{UInt64, Float64}}}\u001b[22m\u001b[39m\n",
+      "\u001b[90m└──\u001b[39m      return %4\n",
       "\n"
      ]
     }
@@ -909,10 +932,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73762293-eed1-494f-8a15-05ed7a030c64",
+   "metadata": {},
+   "source": [
+    "------------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "198934dc-3fba-4d34-bc0e-ce336734aed2",
+   "metadata": {},
+   "source": [
+    "#### NOTE:\n",
+    "Due to ongoing changes in the code base and unclear compiler optimizations, this example works \"better than expected\". Please stay put and feel free pretending like this function was slower than our implementation. In earlier versions of the code it was, and for other gates it may still be."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53392895-cbc9-49fe-8995-2cacde5c3542",
+   "metadata": {},
+   "source": [
+    "------------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b1e1ed60-69d3-4216-ab2d-a22e1ec42c29",
    "metadata": {},
    "source": [
-    "It either returns a tuple `Tuple{UInt64, Float64}` of length 2 or a tuple `Tuple{UInt64, Float64, UInt64, Float64}` of length 4. When this is the case, you may want to define some lower-level function under `propagate` for optimal performance. This is how we would do it. Yellow `@code_warntype` output means it might be okay (it is not that much slower after all), but be wary of red."
+    "It either returns a tuple of one tuple `Tuple{Tuple{UInt64, Float64}}` or a tuple of two tuples `Tuple{Tuple{UInt64, Float64}, Tuple{UInt64, Float64}}`. Yellow `@code_warntype` output means it might be okay (it is not that much slower after all), but be wary of red. When this is the case, you may want to define some more involved functions above `apply()` for optimal performance. This is how we would do it. "
    ]
   },
   {
@@ -930,27 +978,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "function PauliPropagation.applyandadd!(gate::CustomTGate, pstr, coefficient, theta, output_psum; kwargs...)\n",
+    "function PauliPropagation.applyandadd!(gate::CustomTGate, pstr, coeff, theta, output_psum; kwargs...)\n",
     "    \n",
     "    pauli = getpauli(pstr, gate.qind)\n",
     "    \n",
     "    if pauli == 0 || pauli == 3  # I or Z commute\n",
-    "        add!(output_psum, pstr, coefficient)\n",
+    "        add!(output_psum, pstr, coeff)\n",
     "        return\n",
     "    end\n",
     "\n",
     "    if pauli == 1 # X goes to X, -Y\n",
     "        new_pauli = 2  # Y\n",
     "        new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
-    "        new_coefficient = -1 * coefficient * sin(π/4)\n",
+    "        new_coeff = -1 * coeff * sin(π/4)\n",
     "    else # Y goes to Y, X\n",
     "        new_pauli = 1  # X\n",
     "        new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
-    "        new_coefficient = coefficient * sin(π/4)\n",
+    "        new_coeff = coeff * sin(π/4)\n",
     "    end\n",
     "\n",
-    "    add!(output_psum, pstr, coefficient * cos(π/4))\n",
-    "    add!(output_psum, new_pstr, new_coefficient)\n",
+    "    updated_coeff = coeff * cos(π/4)\n",
+    "    \n",
+    "    add!(output_psum, pstr, updated_coeff)\n",
+    "    add!(output_psum, new_pstr, new_coeff)\n",
     "\n",
     "    return\n",
     "end"
@@ -974,7 +1024,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.041896 seconds (24.27 k allocations: 3.164 MiB, 84.09% compilation time: 100% of which was recompilation)\n"
+      "  0.064480 seconds (39.50 k allocations: 2.093 MiB, 89.71% compilation time: 100% of which was recompilation)\n"
      ]
     }
    ],
@@ -991,7 +1041,7 @@
     {
      "data": {
       "text/plain": [
-       "0.3326289935884039"
+       "0.33262899358840403"
       ]
      },
      "execution_count": 36,
@@ -1042,7 +1092,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  6.475 ms (1154 allocations: 1.64 MiB)\n"
+      "  6.479 ms (1045 allocations: 273.09 KiB)\n"
      ]
     }
    ],
@@ -1060,12 +1110,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  6.083 ms (1158 allocations: 1.79 MiB)\n"
+      "  6.487 ms (1250 allocations: 326.22 KiB)\n"
      ]
     }
    ],
    "source": [
-    "@btime propagate($frozenZ_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
+    "@btime propagate($libraryT_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
    ]
   },
   {
@@ -1085,7 +1135,7 @@
    "source": [
     "function PauliPropagation.applytoall!(gate::CustomTGate, theta, psum, aux_psum; kwargs...)\n",
     "    \n",
-    "    for (pstr, coefficient) in psum \n",
+    "    for (pstr, coeff) in psum \n",
     "    \n",
     "        pauli = getpauli(pstr, gate.qind)\n",
     "\n",
@@ -1097,15 +1147,17 @@
     "        if pauli == 1 # X goes to X, -Y\n",
     "            new_pauli = 2  # Y\n",
     "            new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
-    "            new_coefficient = -1 * coefficient * sin(π/4)\n",
+    "            new_coeff = -1 * coeff * sin(π/4)\n",
     "        else # Y goes to Y, X\n",
     "            new_pauli = 1  # X\n",
     "            new_pstr = setpauli(pstr, new_pauli, gate.qind)\n",
-    "            new_coefficient = coefficient * sin(π/4)\n",
+    "            new_coeff = coeff * sin(π/4)\n",
     "        end\n",
     "\n",
-    "        set!(psum, pstr, coefficient * cos(π/4))\n",
-    "        set!(aux_psum, new_pstr, new_coefficient)\n",
+    "        updated_coeff = coeff * cos(π/4)\n",
+    "\n",
+    "        set!(psum, pstr, updated_coeff)\n",
+    "        set!(aux_psum, new_pstr, new_coeff)\n",
     "    end\n",
     "    return\n",
     "end"
@@ -1121,7 +1173,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  0.063213 seconds (23.54 k allocations: 3.222 MiB, 90.11% compilation time: 100% of which was recompilation)\n"
+      "  0.064533 seconds (29.42 k allocations: 1.681 MiB, 89.65% compilation time: 100% of which was recompilation)\n"
      ]
     }
    ],
@@ -1138,7 +1190,7 @@
     {
      "data": {
       "text/plain": [
-       "0.3326289935884039"
+       "0.33262899358840403"
       ]
      },
      "execution_count": 42,
@@ -1189,7 +1241,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  6.059 ms (1158 allocations: 1.79 MiB)\n"
+      "  6.557 ms (1050 allocations: 319.97 KiB)\n"
      ]
     }
    ],
@@ -1207,12 +1259,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  6.057 ms (1158 allocations: 1.79 MiB)\n"
+      "  6.502 ms (1250 allocations: 326.22 KiB)\n"
      ]
     }
    ],
    "source": [
-    "@btime propagate($frozenZ_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
+    "@btime propagate($libraryT_circuit, $pstr, $thetas; min_abs_coeff=$min_abs_coeff);"
    ]
   },
   {
@@ -1226,15 +1278,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.2",
+   "display_name": "Julia 1.11.2",
    "language": "julia",
-   "name": "julia-1.10"
+   "name": "julia-1.11"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.2"
+   "version": "1.11.2"
   }
  },
  "nbformat": 4,

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -120,6 +120,7 @@ After this functions, Pauli strings in remaining in `psum` and `output_psum` are
 This function can be overwritten for a custom gate if the lower-level functions `applyandadd!` and `apply` are not sufficient.
 In particular, this function can be used to manipulate both `psum` and `output_psum` at the same time to reduce memory movement.
 Note that manipulating `psum` on anything other than the current Pauli string will likely lead to errors.
+See the `4-custom-gates.ipynb` for examples of how to define custom gates.
 """
 function applytoall!(gate, theta, psum, output_psum; kwargs...)
 
@@ -142,15 +143,15 @@ end
 This function can be overwritten for a custom gate if the lower-level function `apply` is not sufficient. 
 This is likely the the case if `apply` is not type-stable because it does not return a unique number of outputs. 
 E.g., a Pauli gate returns 1 or 2 (pstr, coefficient) outputs.
+See the `4-custom-gates.ipynb` for examples of how to define custom gates.
 """
 @inline function applyandadd!(gate, pstr, coeff, theta, output_psum; kwargs...)
 
-    # Get the (potentially new) pauli strings and their coefficients like (pstr1, coeff1, pstr2, coeff2, ...)
+    # Get the (potentially new) pauli strings and their coefficients in the form of ((pstr1, coeff1), (pstr2, coeff2), ...)
     pstrs_and_coeffs = apply(gate, pstr, coeff, theta; kwargs...)
 
-    for ii in 1:2:length(pstrs_and_coeffs)
+    for (new_pstr, new_coeff) in pstrs_and_coeffs
         # Itererate over the pairs of pstr and coeff
-        new_pstr, new_coeff = pstrs_and_coeffs[ii], pstrs_and_coeffs[ii+1]
         # Store the new_pstr and coeff in the aux_psum, add to existing coeff if new_pstr already exists there
         add!(output_psum, new_pstr, new_coeff)
     end
@@ -164,6 +165,7 @@ end
 
 Calling apply on a `StaticGate` will dispatch to a 3-argument apply function without the paramter `theta`.
 If a 4-argument apply function is defined for a concrete type, it will still dispatch to that one.
+See the `4-custom-gates.ipynb` for examples of how to define custom gates.
 """
 apply(gate::SG, pstr, coeff, theta; kwargs...) where {SG<:StaticGate} = apply(gate, pstr, coeff; kwargs...)
 

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -101,6 +101,7 @@ function apply(gate::CliffordGate, pstr::PauliStringType, coeff; kwargs...)
 
     coeff *= sign
 
+    # usually return format would be ((pstr, coeff), ), but we also overload applyandadd!() to accept this
     return pstr, coeff
 end
 


### PR DESCRIPTION
We go from `Tuple{TermType, CoeffType, TermType, CoeffType ...}` to `Tuple{Tuple{TermType, CoeffType}, ...}`. 

This is more human-readable and will synergize nicely with future PTM features. 

As a side bonus, the T-gate example in the `examples/4-custom-gates.ipynb` notebook now suddenly works optimally by just defining  `apply()`. I don't know what compiler wizardry is going on here, but we will find it out. 