### PR TITLE
lower Statistics.jl compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,13 @@ BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 Bits = "1654ce90-6ed3-553a-957f-9452c3a40996"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 BitIntegers = "0.3"
 Bits = "0.2"
-Statistics = "1.9"
+StatsBase = "0.34"
 julia = "1.6.7"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 BitIntegers = "0.3"
 Bits = "0.2"
-Statistics = "1.11"
+Statistics = "1.9"
 julia = "1.6.7"
 
 [extras]

--- a/src/numericalcertificates.jl
+++ b/src/numericalcertificates.jl
@@ -1,4 +1,4 @@
-using Statistics
+using StatsBase
 
 """
     estimatemse(circ, pstr::PauliString, n_mcsamples::Integer, thetas=π; stateoverlapfunc=overlapwithzero, circuit_is_reversed=false, customtruncfunc=nothing)


### PR DESCRIPTION
There may be issues in using our library with Julia 1.10 or below due to the Statistics compat.