### PR TITLE
enable doc-gen from non-main branches

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,17 +1,23 @@
 # Generates the package documentation via Documenter.jl,
 # and deploys it to Github Pages, as per the hosting guide
-# at https://documenter.juliadocs.org/stable/man/hosting/
+# at https://documenter.juliadocs.org/stable/man/hosting/.
+# See /docs/make.jl for more information about generation.
 
 name: Documentation
 
 
-# Regenerate doc whenever the below main is updated, or
-# the workflow is manually triggered from the Actions tab
+# Regenerate doc (updating Github Pages site) whenever...
 on:
+  # main is updated (updates root site with new release)
   push:
     branches:
       - main
-      - doc-fix
+  # a PR is opened to the below branches (updates /previews/PR#)
+  pull_request:
+    branches:
+      - main
+      - dev
+  # the workflow is manually triggered from the Actions tab (updates /dev/)
   workflow_dispatch:
 
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - doc-fix
   workflow_dispatch:
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+IF YOU SEE THIS, DOCUMENTER.JL CONSULTED doc-fix BRANCH
+
 # PauliPropagation.jl
 `PauliPropagation.jl` is a Julia package for Pauli propagation simulation of quantum circuits and quantum systems.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-(testing whether this is visible in CI doc)
-
 # PauliPropagation.jl
 `PauliPropagation.jl` is a Julia package for Pauli propagation simulation of quantum circuits and quantum systems.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-IF YOU SEE THIS, DOCUMENTER.JL CONSULTED doc-fix BRANCH
-
 # PauliPropagation.jl
 `PauliPropagation.jl` is a Julia package for Pauli propagation simulation of quantum circuits and quantum systems.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+(testing whether this is visible in CI doc)
+
 # PauliPropagation.jl
 `PauliPropagation.jl` is a Julia package for Pauli propagation simulation of quantum circuits and quantum systems.
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,11 @@ makedocs(
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
 
+    # do not place in-development doc under a /dev/ sub-domain,
+    # since we'll instead preview doc straight from PRs (as below)
+    # and do not wish to encourage distributing the wrong URL
+    devurl="",
+
     # enable generation of doc from PRs, under a /previews/PR## sub-domain
     push_preview=true,
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,11 +26,6 @@ makedocs(
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
 
-    # do not place in-development doc under a /dev/ sub-domain,
-    # since we'll instead preview doc straight from PRs (as below)
-    # and do not wish to encourage distributing the wrong URL
-    devurl="",
-
     # enable generation of doc from PRs, under a /previews/PR## sub-domain
     push_preview=true,
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,5 +25,12 @@ makedocs(
 # enables doc site deployment to Github Pages
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
-    devbranch="dev"
+
+    # do not place in-development doc under a /dev/ sub-domain,
+    # since we'll instead preview doc straight from PRs (as below)
+    # and do not wish to encourage distributing the wrong URL
+    devurl="",
+
+    # enable generation of doc from PRs, under a /previews/PR## sub-domain
+    push_preview=true
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,26 @@
+# Generates HTML documentation from the contents of
+# the docs folder, triggered locally by command
+#   julia --project make.jl
+# 
+# If triggered within a Github Action, the generated
+# HTML files will then be committed to the 'gh-pages'
+# branch, which Github Pages can be configured to
+# display at msrudolph.github.io/PauliPropagation.jl/
+# 
+# Note documentation generated from non-main branches
+# will be uploaded to subdomain /dev/, even when not
+# from the 'dev' branch, and doc generated from pull
+# requests will be uploaded to /previews/PR#.
+
+
 using Documenter, PauliPropagation
 
-# determines doc site layout
+
+# Generate doc HTML files, saved to build/
 makedocs(
     sitename="Pauli Propagation",
+
+    # determines site layout
     pages=[
         "index.md",
         "installation.md",
@@ -22,21 +40,22 @@ makedocs(
     ]
 )
 
-# enables doc site deployment to Github Pages
+
+# When run from a Github Action, commit those files to the 'gh-pages' branch.
+# If the action's invoking branch is not main, the files are uploaded under /dev/
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
 
-    # do not place in-development doc under a /dev/ sub-domain,
-    # since we'll instead preview doc straight from PRs (as below)
-    # and do not wish to encourage distributing the wrong URL
-    devurl="",
-
-    # enable generation of doc from PRs, under a /previews/PR## sub-domain
-    push_preview=true,
-
-    # DEBUG
-    # this forces deploydocs to upload to gh-pages when the invoking branch is
-    # not "main" (the default). Otherwise, despite push_preview=true, the upload
-    # is cancelled because ENV["GITHUB_REF"] does not match devbranch="main". Bug??
-    devbranch="doc-fix"
+    # Enable generation of doc from PRs, under a /previews/PR## sub-domain.
+    # Beware that this requires the Github Action was explicitly triggered by
+    # a 'pull_request' event (not a 'push')
+    push_preview=true
 )
+
+
+# Once 'gh-pages' branch is updated, and Github Pages has been configured to
+# publish files from that branch, the documentation is visible at either:
+# - msrudolph.github.io/PauliPropagation.jl/
+# - msrudolph.github.io/PauliPropagation.jl/dev/
+# - msrudolph.github.io/PauliPropagation.jl/previews/PR#
+# where # above is replaced with the pull request number

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,5 +32,11 @@ deploydocs(
     devurl="",
 
     # enable generation of doc from PRs, under a /previews/PR## sub-domain
-    push_preview=true
+    push_preview=true,
+
+    # DEBUG
+    # this forces deploydocs to upload to gh-pages when the invoking branch is
+    # not "main" (the default). Otherwise, despite push_preview=true, the upload
+    # is cancelled because ENV["GITHUB_REF"] does not match devbranch="main". Bug??
+    devbranch="doc-fix"
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,4 +25,5 @@ makedocs(
 # enables doc site deployment to Github Pages
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
+    devbranch="dev"
 )


### PR DESCRIPTION
Testing whether doc can be generated from a PR branch rather than main