### PR TITLE
Argument order and filter function convention

### DIFF
--- a/examples/8-automatic-differentiation.ipynb
+++ b/examples/8-automatic-differentiation.ipynb
@@ -364,7 +364,7 @@
     "    CoeffType = eltype(thetas)\n",
     "\n",
     "    # define H again \n",
-    "    H = PauliSum(nq, CoeffType)\n",
+    "    H = PauliSum(CoeffType, nq)\n",
     "    for qind in 1:nq\n",
     "        add!(H, :X, qind, CoeffType(1.0))\n",
     "    end\n",

--- a/src/PauliAlgebra/datatypes.jl
+++ b/src/PauliAlgebra/datatypes.jl
@@ -121,14 +121,14 @@ end
 
 Contructor for an empty `PauliSum` on `nqubits` qubits. Element type defaults for Float64.
 """
-PauliSum(nqubits::Int) = PauliSum(nqubits, Float64)
+PauliSum(nqubits::Int) = PauliSum(Float64, nqubits)
 
 """
-    PauliSum(nq::Int, COEFFTYPE)
+    PauliSum(CoeffType, nq::Int)
 
 Contructor for an empty `PauliSum` on `nqubits` qubits. The type of the coefficients can be provided.
 """
-function PauliSum(nq::Int, ::Type{CT}) where {CT}
+function PauliSum(::Type{CT}, nq::Int) where {CT}
     TT = getinttype(nq)
     return PauliSum(nq, Dict{TT,CT}())
 end
@@ -175,7 +175,7 @@ function PauliSum(pstrs::Union{AbstractArray,Tuple,Base.Generator})
 
     nq = first(pstrs).nqubits
     # TODO: figure out type what to do when type of coefficients is not the same
-    psum = PauliSum(nq, coefftype(first(pstrs)))
+    psum = PauliSum(coefftype(first(pstrs)), nq)
     sizehint!(psum.terms, length(pstrs))
     for pstr in pstrs
         add!(psum, pstr)

--- a/src/PauliAlgebra/datatypes.jl
+++ b/src/PauliAlgebra/datatypes.jl
@@ -674,11 +674,11 @@ Base.empty!(psum::PauliSum) = empty!(psum.terms)
 Create a new `PauliSum` with the same number of qubits and coefficient type as `psum`.
 Calls `sizehint!()` with `length(psum)` on the dictionary of the new `PauliSum`. 
 """
-function similar(psum::PauliSum)
+function Base.similar(psum::PauliSum)
     return PauliSum(psum.nqubits, similar(psum.terms))
 end
 
-function similar(psum::Dict{TT,CT}) where {TT,CT}
+function Base.similar(psum::Dict{TT,CT}) where {TT,CT}
     new_psum = Dict{TT,CT}()
     sizehint!(new_psum, length(psum))
     return new_psum

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -22,6 +22,7 @@ export
     set!,
     mult!,
     empty!,
+    similar,
     identitypauli,
     identitylike,
     inttosymbol,

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -310,7 +310,11 @@ end
 function _check_unwrap_from_paulifreqtracker(::Type{CT}, psum::PauliSum{TT,PFT}) where {TT,CT,PFT<:PauliFreqTracker}
     # in this function is for when the original coefficient type was not `PauliFreqTracker` but that is what we have
     # we need to unwrap the coefficients
-    psum = unwrapcoefficients(psum)
+
+    # if CT is not PFT, unwrap
+    if !(CT == PFT)
+        psum = unwrapcoefficients(psum)
+    end
     return psum
 end
 

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -311,7 +311,7 @@ function _check_unwrap_from_paulifreqtracker(::Type{CT}, psum::PauliSum{TT,PFT})
     # in this function is for when the original coefficient type was not `PauliFreqTracker` but that is what we have
     # we need to unwrap the coefficients
 
-    # if CT is not PFT, unwrap
+    # if the original coefficient type (CT) is not PauliFreqTracker (PFT), then unwrap
     if !(CT == PFT)
         psum = unwrapcoefficients(psum)
     end

--- a/src/stateoverlap.jl
+++ b/src/stateoverlap.jl
@@ -165,7 +165,7 @@ end
 
 Return a filtered `PauliSum` by removing all Pauli strings for which `filterfunc(pstr, coeff)` returns `false`.
 """
-function filter(filterfunc::F, psum::PauliSum) where {F<:Function}
+function Base.filter(filterfunc::F, psum::PauliSum) where {F<:Function}
     # iterating over dictionaries returns pairs like key=>value
     # so we need to unpack them to use the in-built Julia filter function
     filtered_terms = Base.filter(pair -> filterfunc(pair...), psum.terms)
@@ -177,7 +177,7 @@ end
 
 Filter a `PauliSum` in-place by removing all Pauli strings for which `filterfunc(pstr, coeff)` returns `false`.
 """
-function filter!(filterfunc::F, psum::PauliSum) where {F<:Function}
+function Base.filter!(filterfunc::F, psum::PauliSum) where {F<:Function}
     # iterating over dictionaries returns pairs like key=>value
     # so we need to unpack them to use the in-built Julia filter function
     Base.filter!(pair -> filterfunc(pair...), psum.terms)

--- a/src/stateoverlap.jl
+++ b/src/stateoverlap.jl
@@ -1,21 +1,21 @@
 ### This file contains the functions to calculate the overlap between between backpropagated pauli strings and states or general operators.
 
 """
-    overlapbyorthogonality(psum::PauliSum, orthogonalfunc::Function)
+    overlapbyorthogonality(orthogonalfunc::Function, psum::PauliSum)
 
 Overlap a `PauliSum` with a state or operator via function that returns true if a Pauli string is orthogonal and hence doesn't contribute.
 An example `orthogonalfunc` is `containsXorY` which returns true if a Pauli string contains an X or Y Pauli.
 If not orthogonal, then a Pauli string contributes with its coefficient.
 This is particularly useful for overlaps with stabilizer states.
 """
-function overlapbyorthogonality(psum::PauliSum, orthogonalfunc::F) where {F<:Function}
+function overlapbyorthogonality(orthogonalfunc::F, psum::PauliSum) where {F<:Function}
     if length(psum) == 0
         return 0.0
     end
 
     val = zero(numcoefftype(psum))
     for (pstr, coeff) in psum
-        if overlapbyorthogonality(pstr, orthogonalfunc)
+        if overlapbyorthogonality(orthogonalfunc, pstr)
             val += tonumber(coeff)
         end
     end
@@ -23,26 +23,26 @@ function overlapbyorthogonality(psum::PauliSum, orthogonalfunc::F) where {F<:Fun
 end
 
 """
-    overlapbyorthogonality(pstr::PauliString, orthogonalfunc::Function)
+    overlapbyorthogonality(orthogonalfunc::Function, pstr::PauliString)
 
 Overlap a `PauliString` with a state or operator via function that returns true if the `PauliString` is orthogonal and hence has overlap 0.
  An example `orthogonalfunc` is `containsXorY` which returns true if the `PauliString` contains an X or Y Pauli.
 If not orthogonal, then the overlap is the coefficient of the `PauliString`.
 This is particularly useful for overlaps with stabilizer states.
 """
-function overlapbyorthogonality(pstr::PauliString, orthogonalfunc::F) where {F<:Function}
+function overlapbyorthogonality(orthogonalfunc::F, pstr::PauliString) where {F<:Function}
     return !orthogonalfunc(pstr) * tonumber(pstr.coeff)
 end
 
 """
-    overlapbyorthogonality(pstr::PauliString, orthogonalfunc::Function)
+    overlapbyorthogonality(orthogonalfunc::Function, pstr::PauliString)
 
 Overlap an integer Pauli string with a state or operator via function that returns true if the Pauli string is orthogonal and hence has overlap 0.
  An example `orthogonalfunc` is `containsXorY` which returns true if the Pauli string contains an X or Y Pauli.
 If not orthogonal, then the overlap is 1.
 This is particularly useful for overlaps with stabilizer states.
 """
-function overlapbyorthogonality(pstr::PauliStringType, orthogonalfunc::F) where {F<:Function}
+function overlapbyorthogonality(orthogonalfunc::F, pstr::PauliStringType) where {F<:Function}
     return !orthogonalfunc(pstr)
 end
 
@@ -52,7 +52,7 @@ end
 
 Calculates the overlap of a Pauli sum with the zero state |0><0|
 """
-overlapwithzero(psum) = overlapbyorthogonality(psum, orthogonaltozero)
+overlapwithzero(psum) = overlapbyorthogonality(orthogonaltozero, psum)
 
 """
     overlapwithzero(pstr) 
@@ -66,7 +66,7 @@ orthogonaltozero(pstr) = containsXorY(pstr)
 
 Calculates the overlap of a Pauli sum with the plus state |+><+|
 """
-overlapwithplus(psum) = overlapbyorthogonality(psum, orthogonaltoplus)
+overlapwithplus(psum) = overlapbyorthogonality(orthogonaltoplus, psum)
 
 """
     orthogonaltoplus(pstr) 
@@ -161,37 +161,26 @@ end
 
 
 """
-    filter(psum::PauliSum, filterfunc::Function)
+    filter(filterfunc::Function, psum::PauliSum)
 
-Return a filtered `PauliSum` by removing all Pauli strings that satisfy the `filterfunc`.
+Return a filtered `PauliSum` by removing all Pauli strings for which `filterfunc(pstr, coeff)` returns `false`.
 """
-function filter(psum::PauliSum, filterfunc::F) where {F<:Function}
-    op_dict = filter(psum.terms, filterfunc)
-    return PauliSum(psum.nqubits, op_dict)
+function filter(filterfunc::F, psum::PauliSum) where {F<:Function}
+    # iterating over dictionaries returns pairs like key=>value
+    # so we need to unpack them to use the in-built Julia filter function
+    filtered_terms = Base.filter(pair -> filterfunc(pair...), psum.terms)
+    return PauliSum(psum.nqubits, filtered_terms)
 end
 
 """
-    filter!(psum::PauliSum, filterfunc::Function)
+    filter!(filterfunc::Function, psum::PauliSum)
 
-Filter a `PauliSum` in-place by removing all Pauli strings that satisfy the `filterfunc`.
+Filter a `PauliSum` in-place by removing all Pauli strings for which `filterfunc(pstr, coeff)` returns `false`.
 """
-function filter!(psum::PauliSum, filterfunc::F) where {F<:Function}
-    filter!(psum.terms, filterfunc)
-    return psum
-end
-
-# Lower-level filter function for Dict
-function filter(psum::Dict, filterfunc::F) where {F<:Function}
-    return Dict(k => v for (k, v) in psum if !filterfunc(k))
-end
-
-# Lower-level in-place filter function for Dict
-function filter!(psum::Dict, filterfunc::F) where {F<:Function}
-    for pstr in keys(psum)
-        if filterfunc(pstr)
-            delete!(psum, pstr)
-        end
-    end
+function filter!(filterfunc::F, psum::PauliSum) where {F<:Function}
+    # iterating over dictionaries returns pairs like key=>value
+    # so we need to unpack them to use the in-built Julia filter function
+    Base.filter!(pair -> filterfunc(pair...), psum.terms)
     return psum
 end
 
@@ -202,28 +191,28 @@ end
 
 Return a filtered Pauli sum with only Pauli strings that are not orthogonal to the zero state |0><0|.
 """
-zerofilter(psum) = filter(psum, containsXorY)
+zerofilter(psum) = filter((pstr, coeff) -> !containsXorY(pstr), psum)
 
 """
     zerofilter!(psum)
 
 Filter a Pauli sum in-place with only Pauli strings that are not orthogonal to the zero state |0><0|.
 """
-zerofilter!(psum) = filter!(psum, containsXorY)
+zerofilter!(psum) = filter!((pstr, coeff) -> !containsXorY(pstr), psum)
 
 """
     plusfilter(psum)
 
 Return a filtered Pauli sum with only Pauli strings that are not orthogonal to the plus state |+><+|.
 """
-plusfilter(psum) = filter(psum, containsYorZ)
+plusfilter(psum) = filter((pstr, coeff) -> !containsYorZ(pstr), psum)
 
 """
     zerofilter!(psum)
 
 Filter a Pauli sum in-place with only Pauli strings that are not orthogonal to the plus state |+><+|.
 """
-plusfilter!(psum) = filter!(psum, containsYorZ)
+plusfilter!(psum) = filter!((pstr, coeff) -> !containsYorZ(pstr), psum)
 
 
 


### PR DESCRIPTION
In this PR we change the argument order of 
- coefficient type for an empty `PauliSum` constructor to the first argument
- function for overlap and filtering to the first argument.
This is standard in other similar Julia function.

Furthermore, we adapt `filter()` and `filter!()` for `PauliSum` so that the filter function takes arguments `(pstr, coeff)`, adhering to the standard of `Base.filter` where the function receives whatever the collection iterates.

Fixed the export of `filter` and `similar` by explicitly overloading `Base.filter` and `Base.similar`.

Unrelated bug fix for propagation of `PauliFreqTracker` coefficients. Came from #78 . 