### PR TITLE
Comment docstings

### DIFF
--- a/src/Gates/frozengates.jl
+++ b/src/Gates/frozengates.jl
@@ -33,7 +33,7 @@ function freeze(gate::ParametrizedGate, parameter::Number)
 end
 
 """
-    freeze(gates, parameters)
+    freeze(gates::Vector{Gate}, parameters::Vector{Number})
 
 Returns a vector of `Gate`s where `ParametrizedGate`s are frozen with their `parameters`.
 """

--- a/src/Gates/noisechannels.jl
+++ b/src/Gates/noisechannels.jl
@@ -56,8 +56,10 @@ struct PauliXNoise <: PauliNoise
 
     @doc """
         PauliXNoise(qind::Int)
+        PauliXNoise(qind::Int, p::Real)
 
     A Pauli-X noise channel acting on the qubit at index `qind`.
+    If `p` is provided, this returns a frozen gate with that noise strength.
     Will damp Y and Z Paulis equally by a factor of `1-p`.
     This corresponds to inserting a random Pauli X operator into the circuit with probability `p/2`.
     """
@@ -65,13 +67,7 @@ struct PauliXNoise <: PauliNoise
 end
 
 
-"""
-    PauliXNoise(qind::Int, p::Real)
-
-A frozen Pauli-X noise channel acting on the qubit at index `qind` with noise strength `p`.
-Will damp Y and Z Paulis equally by a factor of `1-p`.
-This corresponds to inserting a random Pauli X operator into the circuit with probability `p/2`.
-"""
+# the frozen gate version
 function PauliXNoise(qind::Int, p::Real)
     _check_noise_strength(DephasingNoise, p)
 
@@ -90,8 +86,10 @@ struct PauliYNoise <: PauliNoise
 
     @doc """
         PauliYNoise(qind::Int)
+        PauliYNoise(qind::Int, p::Real)
 
     A Pauli-Y noise channel acting on the qubit at index `qind`.
+    If `p` is provided, this returns a frozen gate with that noise strength.
     Will damp X and Z Paulis equally by a factor of `1-p`.
     This corresponds to inserting a random Pauli Y operator into the circuit with probability `p/2`.
     """
@@ -99,13 +97,7 @@ struct PauliYNoise <: PauliNoise
 end
 
 
-"""
-    PauliYNoise(qind::Int, p::Real)
-
-A frozen Pauli-Y noise channel acting on the qubit at index `qind` with noise strength `p`.
-Will damp X and Z Paulis equally by a factor of `1-p`.
-This corresponds to inserting a random Pauli Y operator into the circuit with probability `p/2`.
-"""
+# the frozen gate version
 function PauliYNoise(qind::Int, p::Real)
     _check_noise_strength(DephasingNoise, p)
 
@@ -124,21 +116,18 @@ struct PauliZNoise <: PauliNoise
 
     @doc """
         PauliZNoise(qind::Int)
+        PauliZNoise(qind::Int, p::Real)
 
     A Pauli-Z noise channel acting on the qubit at index `qind`.
+    If `p` is provided, this returns a frozen gate with that noise strength.
     Will damp X and Y Paulis equally by a factor of `1-p`.
     This corresponds to inserting a random Pauli Z operator with probability `p/2`.
     """
     PauliZNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
-"""
-    PauliZNoise(qind::Int, p::Real)
 
-A frozen Pauli-Z noise channel acting on the qubit at index `qind` with noise strength `p`.
-Will damp X and Y Paulis equally by a factor of `1-p`.
-This corresponds to inserting a random Pauli Z operator into the circuit with probability `p/2`.
-"""
+# the frozen gate version 
 function PauliZNoise(qind::Int, p::Real)
     _check_noise_strength(DephasingNoise, p)
 
@@ -150,15 +139,16 @@ function isdamped(::PauliZNoise, pauli::PauliType)
     return pauli == 1 || pauli == 2
 end
 
+
 ## DepolarizingNoise is an alias for PauliZNoise
 """
     DephasingNoise(qind::Int)
     DephasingNoise(qind::Int, p::Real)
 
 This is an alias for `PauliZNoise`.
+If `p` is provided, this returns a frozen gate with that noise strength.
 A dephasing noise channel acting on the qubit at index `qind`.
 Will damp X and Y Paulis equally by a factor of `1-p`.
-If `p` is provided, this returns a frozen gate with that noise strength.
 """
 const DephasingNoise = PauliZNoise
 
@@ -171,24 +161,24 @@ struct PauliXDamping <: PauliNoise
 
     @doc """
         PauliXDamping(qind::Int)
+        PauliXDamping(qind::Int, p::Real)
 
     A Pauli-X noise damping acting on the qubit at index `qind`.
-    Will damp X Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
+    If `p` is provided, this returns a frozen gate with that damping strength.
+    Will damp X Paulis by a factor of `1-p`. 
+    This alone is not a valid quantum channel.
     """
     PauliXDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
-"""
-    PauliXDamping(qind::Int, p::Real)
 
-A frozen Pauli-X noise damping acting on the qubit at index `qind` with noise strength `p`.
-Will damp X Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
-"""
+# the frozen gate version
 function PauliXDamping(qind::Int, p::Real)
     _check_noise_strength(PauliXDamping, p)
 
     return FrozenGate(PauliXDamping(qind), p)
 end
+
 
 function isdamped(::PauliXDamping, pauli::PauliType)
     return pauli == 1
@@ -202,22 +192,21 @@ struct PauliYDamping <: PauliNoise
         PauliYDamping(qind::Int)
 
     A Pauli-Y noise damping acting on the qubit at index `qind`.
-    Will damp Y Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
+    If `p` is provided, this returns a frozen gate with that damping strength.
+    Will damp Y Paulis by a factor of `1-p`. 
+    This alone is not a valid quantum channel.
     """
     PauliYDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
-"""
-    PauliYDamping(qind::Int, p::Real)
 
-A frozen Pauli-Y damping acting on the qubit at index `qind` with noise strength `p`.
-Will damp Y Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
-"""
+# the frozen gate version
 function PauliYDamping(qind::Int, p::Real)
     _check_noise_strength(PauliYDamping, p)
 
     return FrozenGate(PauliYDamping(qind), p)
 end
+
 
 function isdamped(::PauliYDamping, pauli::PauliType)
     return pauli == 2
@@ -231,17 +220,15 @@ struct PauliZDamping <: PauliNoise
         PauliZDamping(qind::Int)
 
     A Pauli-Z noise damping acting on the qubit at index `qind`.
-    Will damp Z Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
+    If `p` is provided, this returns a frozen gate with that damping strength.
+    Will damp Z Paulis by a factor of `1-p`. 
+    This alone is not a valid quantum channel.
     """
     PauliZDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
-"""
-    PauliZDamping(qind::Int, p::Real)
 
-A frozen Pauli-Z noise damping acting on the qubit at index `qind` with noise strength `p`.
-Will damp Z Paulis by a factor of `1-p`. This alone is not a valid quantum channel.
-"""
+# the frozen gate version
 function PauliZDamping(qind::Int, p::Real)
     _check_noise_strength(PauliZDamping, p)
 
@@ -252,10 +239,13 @@ function isdamped(::PauliZDamping, pauli::PauliType)
     return pauli == 3
 end
 
+## Amplitude damping noise
 """
     AmplitudeDampingNoise(qind::Int)
+    AmplitudeDampingNoise(qind::Int, gamma::Real)
 
 An amplitude damping noise channel acting on the qubit at index `qind`.
+If `gamma` is provided, this returns a frozen gate with that noise strength.
 Damps X and Y Paulis by a factor of sqrt(1-gamma)
 and splits Z into and gamma * I and (1-gamma) * Z component (in the transposed Heisenberg picture).
 """
@@ -263,12 +253,8 @@ struct AmplitudeDampingNoise <: ParametrizedNoiseChannel
     qind::Int
 end
 
-"""
-    AmplitudeDampingNoise(qind::Int, gamma::Real)
 
-A frozen amplitude damping noise channel acting on the qubit at index `qind` with noise strength `gamma`.
-Damps X and Y Paulis, and splits Z into and I and Z component (in the transposed Heisenberg picture).
-"""
+# the frozen gate version
 function AmplitudeDampingNoise(qind::Int, gamma::Real)
     _check_noise_strength(AmplitudeDampingNoise, gamma)
 

--- a/src/Gates/paulirotations.jl
+++ b/src/Gates/paulirotations.jl
@@ -109,12 +109,6 @@ function commutes(gate::PauliRotation, pstr::PauliStringType)
 end
 
 
-# The fast `MaskedPauliRotation` version that we use in propagate()
-function commutes(gate::MaskedPauliRotation, pstr::PauliStringType)
-    return commutes(gate.generator_mask, pstr)
-end
-
-
 
 # A parametrized Pauli rotation gate acting on the qubits `qinds` with the Pauli string `symbols`.
 # The `term` is the integer representation of the Pauli string with the correct integer type for the total number of qubits.
@@ -130,6 +124,11 @@ end
 # Union type for `PauliRotation` and `MaskedPauliRotation`, useful for functions which handle either agnostically.
 PauliRotationUnion = Union{PauliRotation,MaskedPauliRotation}
 
+
+# The fast `MaskedPauliRotation` version that we use in propagate()
+function commutes(gate::MaskedPauliRotation, pstr::PauliStringType)
+    return commutes(gate.generator_mask, pstr)
+end
 
 
 # Returns a circuit where `PauliRotation` gates are transformed to `MaskedPauliRotation` gates.

--- a/src/Gates/paulirotations.jl
+++ b/src/Gates/paulirotations.jl
@@ -89,13 +89,37 @@ end
 
 
 """
-    MaskedPauliRotation(symbols::Vector{Symbol}, qinds::Vector{Int}, term::PauliStringType)
+    commutes(gate::PauliRotation, pstr::PauliString)
 
-A parametrized Pauli rotation gate acting on the qubits `qinds` with the Pauli string `symbols`.
-The `term` is the integer representation of the Pauli string with the correct integer type for the total number of qubits.
-This allows for faster application of the gate.
-See `tomaskedpaulirotation` for conversion from `PauliRotation`, which is the easiest way to construct a `MaskedPauliRotation`.
+Check if a `PauliRotation` commutes with a `PauliString`.
 """
+function commutes(gate::PauliRotation, pstr::PauliString)
+    return commutes(gate, pstr.term)
+end
+
+"""
+    commutes(gate::PauliRotation, pstr::Integer)
+
+Check if a `PauliRotation` commutes with an integer Pauli string.
+"""
+function commutes(gate::PauliRotation, pstr::PauliStringType)
+    # the symbolic version is not worth it so convert to a MaskedPauliRotation
+    masked_gate = _tomaskedpaulirotation(gate, typeof(pstr))
+    return commutes(masked_gate, pstr)
+end
+
+
+# The fast `MaskedPauliRotation` version that we use in propagate()
+function commutes(gate::MaskedPauliRotation, pstr::PauliStringType)
+    return commutes(gate.generator_mask, pstr)
+end
+
+
+
+# A parametrized Pauli rotation gate acting on the qubits `qinds` with the Pauli string `symbols`.
+# The `term` is the integer representation of the Pauli string with the correct integer type for the total number of qubits.
+# This allows for faster application of the gate.
+# See `tomaskedpaulirotation` for conversion from `PauliRotation`, which is the easiest way to construct a `MaskedPauliRotation`.
 struct MaskedPauliRotation{T} <: ParametrizedGate where {T<:PauliStringType}
     symbols::Vector{Symbol}
     qinds::Vector{Int}
@@ -103,31 +127,29 @@ struct MaskedPauliRotation{T} <: ParametrizedGate where {T<:PauliStringType}
 end
 
 
-"""
-    PauliRotationUnion
-
-Union type for `PauliRotation` and `MaskedPauliRotation`, useful for functions which handle either agnostically.
-"""
+# Union type for `PauliRotation` and `MaskedPauliRotation`, useful for functions which handle either agnostically.
 PauliRotationUnion = Union{PauliRotation,MaskedPauliRotation}
 
 
-"""
-    _tomaskedpaulirotation(circ::Vector{Gate})
 
-Returns a circuit where `PauliRotation` gates are transformed to `MaskedPauliRotation` gates.
-This allows for significantly faster computation with the gate.
-"""
+# Returns a circuit where `PauliRotation` gates are transformed to `MaskedPauliRotation` gates.
+# This allows for significantly faster computation with the gate.
 function _tomaskedpaulirotation(circ::Vector{G}, nqubits::Integer) where {G<:Gate}
     TT = getinttype(nqubits)
     return _tomaskedpaulirotation(circ, TT)
 end
 
-"""
-    _tomaskedpaulirotation(circ::Vector{Gate})
 
-Returns a circuit where `PauliRotation` gates are transformed to `MaskedPauliRotation` gates.
-This allows for significantly faster computation with the gate.
-"""
+# Transforms a `PauliRotation` to a `MaskedPauliRotation` which carries the integer representation of the gate generator.
+# This allows for significantly faster computation with the gate.
+function _tomaskedpaulirotation(pauli_gate::PauliRotation, ::Type{TT}) where {TT<:PauliStringType}
+    pstr_term = symboltoint(TT, pauli_gate.symbols, pauli_gate.qinds)
+    return MaskedPauliRotation(pauli_gate.symbols, pauli_gate.qinds, pstr_term)
+end
+
+
+# Returns a circuit where `PauliRotation` gates are transformed to `MaskedPauliRotation` gates.
+# This allows for significantly faster computation with the gate.
 function _tomaskedpaulirotation(circ::Vector{G}, ::Type{TT}) where {G<:Gate,TT<:PauliStringType}
     masked_circ = copy(circ)
     for (ii, gate) in enumerate(masked_circ)
@@ -138,71 +160,27 @@ function _tomaskedpaulirotation(circ::Vector{G}, ::Type{TT}) where {G<:Gate,TT<:
     return masked_circ
 end
 
-"""
-    _tomaskedpaulirotation(pauli_gate::PauliRotation, nqubits::Integer)
 
-Transforms a `PauliRotation` to a `MaskedPauliRotation` which carries the integer representation of the gate generator.
-This allows for significantly faster computation with the gate.
-"""
+# Transforms a `PauliRotation` to a `MaskedPauliRotation` which carries the integer representation of the gate generator.
+# This allows for significantly faster computation with the gate.
 function _tomaskedpaulirotation(pauli_gate::PauliRotation, nqubits::Integer)
     pstr_term = symboltoint(nqubits, pauli_gate.symbols, pauli_gate.qinds)
     return MaskedPauliRotation(pauli_gate.symbols, pauli_gate.qinds, pstr_term)
 end
 
-"""
-    _tomaskedpaulirotation(frozen_gate::FrozenGate, nqubits::Integer)
 
-Transforms a `FrozenGate` with a `PauliRotation` to a `MaskedPauliRotation` 
-which carries the integer representation of the gate generator.
-"""
+# Transforms a `FrozenGate` with a `PauliRotation` to a `MaskedPauliRotation` 
+# which carries the integer representation of the gate generator.
 function _tomaskedpaulirotation(frozen_gate::FrozenGate, nqubits::Integer)
     return FrozenGate(_tomaskedpaulirotation(frozen_gate.gate, nqubits), frozen_gate.theta)
 end
 
-"""
-    _tomaskedpaulirotation(fast_pauli_gate::MaskedPauliRotation, args...)
 
-Return the `MaskedPauliRotation` gate as is.
-"""
+# Return the `MaskedPauliRotation` gate as is.
 function _tomaskedpaulirotation(masked_pauli_gate::MaskedPauliRotation, args...)
     return masked_pauli_gate
 end
 
-"""
-    _tomaskedpaulirotation(pauli_gate::PauliRotation, ::TermType)
-
-Transforms a `PauliRotation` to a `MaskedPauliRotation` which carries the integer representation of the gate generator.
-This allows for significantly faster computation with the gate.
-"""
-function _tomaskedpaulirotation(pauli_gate::PauliRotation, ::Type{TT}) where {TT<:PauliStringType}
-    pstr_term = symboltoint(TT, pauli_gate.symbols, pauli_gate.qinds)
-    return MaskedPauliRotation(pauli_gate.symbols, pauli_gate.qinds, pstr_term)
-end
 
 
-"""
-    commutes(gate::PauliRotation, pstr::PauliString)
 
-Check if a `PauliRotation` commutes with a `PauliString`.
-"""
-function commutes(gate::PauliRotation, pstr::PauliString)
-    return commutes(gate, pstr.term)
-end
-
-"""
-    commutes(gate::PauliRotationUnion, pstr)
-
-Check if a `PauliRotation` commutes with an integer Pauli string.
-"""
-function commutes(gate::PauliRotation, pstr::PauliStringType)
-    return sum(!commutes(gate_sym, getpauli(pstr, qind)) for (qind, gate_sym) in zip(gate.qinds, gate.symbols)) % 2 == 0
-end
-
-"""
-    commutes(gate::MaskedPauliRotation, pstr::PauliStringType)
-
-Check if a `MaskedPauliRotation` commutes with an integer Pauli string.
-"""
-function commutes(gate::MaskedPauliRotation, pstr::PauliStringType)
-    return commutes(gate.generator_mask, pstr)
-end

--- a/src/PathProperties/abstracttype.jl
+++ b/src/PathProperties/abstracttype.jl
@@ -8,16 +8,17 @@
 # This behavior can be changed but then more methods need to be defined.
 ##
 ###
-
+import Base: *
+import Base: +
+import Base: float
 
 """
 Abstract type for wrapping coefficients and record custom path properties
 """
 abstract type PathProperties end
 
-"""
-Pretty print for PathProperties
-"""
+
+# Pretty print for PathProperties
 function Base.show(io::IO, pth::PProp) where {PProp<:PathProperties}
     print(io, "$PProp(")
     for (i, field) in enumerate(fieldnames(PProp))
@@ -30,11 +31,9 @@ function Base.show(io::IO, pth::PProp) where {PProp<:PathProperties}
 
 end
 
-import Base: *
-"""
-Multiplication of the `coeff` field in a `PathProperties` object with a number.
-Requires that the `PathProperties` object has a `coeff` field defined which will be multiplied.
-"""
+
+# Multiplication of the `coeff` field in a `PathProperties` object with a number.
+# Requires that the `PathProperties` object has a `coeff` field defined which will be multiplied.
 function *(path::PProp, val::Number) where {PProp<:PathProperties}
     # multiply the coefficient on the `coeff` field with the value and leave the rest unchanged.
     fields = fieldnames(PProp)
@@ -54,20 +53,18 @@ function *(path::PProp, val::Number) where {PProp<:PathProperties}
     return PProp((updateval(getfield(path, fname), fname) for fname in fields)...)
 end
 
-"""
-Multiplication of a `PathProperties` object with a number.
-Requires that the `PathProperties` object has a `coeff` field defined which will be multiplied.
-"""
+
+# Multiplication of a `PathProperties` object with a number.
+# Requires that the `PathProperties` object has a `coeff` field defined which will be multiplied.
 function *(val::Number, path::PProp) where {PProp<:PathProperties}
     return path * val
 end
 
-import Base: +
-"""
-Addition of two `PathProperties` objects of equal concrete type.
-Adds the `coeff` fields and takes the minimum of the other fields.
-Requires that the `PathProperties` object has a `coeff` field defined.
-"""
+
+
+# Addition of two `PathProperties` objects of equal concrete type.
+# Adds the `coeff` fields and takes the minimum of the other fields.
+# Requires that the `PathProperties` object has a `coeff` field defined.
 function +(path1::PProp, path2::PProp) where {PProp<:PathProperties}
     fields = fieldnames(PProp)
 
@@ -87,7 +84,7 @@ function +(path1::PProp, path2::PProp) where {PProp<:PathProperties}
     return PProp((updateval(getfield(path1, fname), getfield(path2, fname), fname) for fname in fields)...)
 end
 
-import Base: float
+
 """
     float(path::PathProperties)
 

--- a/src/PathProperties/paulifreqtracker.jl
+++ b/src/PathProperties/paulifreqtracker.jl
@@ -30,11 +30,8 @@ Initializes `nsins`, `ncos`, and `freq` to zero.
 PauliFreqTracker(coeff::Number) = PauliFreqTracker(float(coeff), 0, 0, 0)
 
 ### Specializations for PauliRotations that incremet the nsins, ncos, and freq
-"""
-    applytoall!(gate::PauliRotation, theta, psum, aux_psum; kwargs...)
 
-Overload of `applytoall!` for `PauliRotation` gates acting onto Pauli sums with `PathProperties` coefficients. 
-"""
+# Overload of `applytoall!` for `PauliRotation` gates acting onto Pauli sums with `PathProperties` coefficients. 
 function applytoall!(gate::PauliRotation, theta, psum::PauliSum{TT,PProp}, aux_psum; kwargs...) where {TT<:PauliStringType,PProp<:PathProperties}
     # turn the (potentially) PauliRotation gate into a MaskedPauliRotation gate
     # this allows for faster operations

--- a/src/PauliAlgebra/bitoperations.jl
+++ b/src/PauliAlgebra/bitoperations.jl
@@ -58,11 +58,7 @@ end
 Base.hash(v::BitIntegers.AbstractBitUnsigned, h::UInt) = Base.hash_integer(v, h)
 
 
-"""
-    _countbitweight(pstr::PauliStringType)
-
-This function counts the number of 00 bit pairs in the integer Pauli string.
-"""
+# This function counts the number of 00 bit pairs in the integer Pauli string.
 function _countbitweight(pstr::PauliStringType)
     # get our super bit mask looking like ....1010101.
     mask = alternatingmask(pstr)
@@ -80,11 +76,8 @@ function _countbitweight(pstr::PauliStringType)
     return count_ones(res)
 end
 
-"""
-     _countbitxy(pstr::PauliStringType)
 
-This function counts the number of 01 (X) or 10 (Y) bit pairs in the integer Pauli string.
-"""
+# This function counts the number of 01 (X) or 10 (Y) bit pairs in the integer Pauli string.
 function _countbitxy(pstr::PauliStringType)
     # we use that 01 and 10 have exactly one 1 and one 0
 
@@ -101,11 +94,8 @@ function _countbitxy(pstr::PauliStringType)
     return count_ones(op)
 end
 
-"""
-    _countbityz(pstr::PauliStringType)
 
-This function counts the number of 10 (Y) or 11 (Z) bit pairs in the integer Pauli string.
-"""
+# This function counts the number of 10 (Y) or 11 (Z) bit pairs in the integer Pauli string.
 function _countbityz(pstr::PauliStringType)
     # we use that both have a 1 on the left bit
 
@@ -119,11 +109,8 @@ function _countbityz(pstr::PauliStringType)
     return count_ones(op)
 end
 
-"""
-    _bitcommutes(pstr1::PauliStringType, pstr2::PauliStringType)
 
-This function checks if two integer Pauli strings commute.
-"""
+# This function checks if two integer Pauli strings commute.
 function _bitcommutes(pstr1::PauliStringType, pstr2::PauliStringType)
 
     mask0 = alternatingmask(pstr1)
@@ -146,11 +133,8 @@ function _bitcommutes(pstr1::PauliStringType, pstr2::PauliStringType)
     return (count_ones(flags) % 2) == 0
 end
 
-"""
-    _bitpaulimultiply(pstr1::PauliStringType, pstr2::PauliStringType)
 
-XOR between two Pauli different non-identity strings gives the third one. Ignores signs or any coefficient.
-"""
+# XOR between two Pauli different non-identity strings gives the third one. Ignores signs or any coefficient.
 _bitpaulimultiply(pstr1::PauliStringType, pstr2::PauliStringType) = pstr1 ⊻ pstr2
 
 """
@@ -161,11 +145,8 @@ Shift to the right and truncate the first encoded Pauli string. Just a utility f
 _paulishiftright(pstr::PauliStringType) = pstr >> 2
 
 
-"""
-    _getpaulibits(pstr::PauliStringType, index::Integer)
 
-This function extracts the Pauli at position `index` from the integer Pauli string.
-"""
+# This function extracts the Pauli at position `index` from the integer Pauli string.
 function _getpaulibits(pstr::PauliStringType, index::Integer)
     # we need to shift the integer by 2 * (index - 1), then the first two bits are target Pauli
     bitindex = 2 * (index - 1)
@@ -177,11 +158,8 @@ function _getpaulibits(pstr::PauliStringType, index::Integer)
     return shifted_pstr & typeof(pstr)(3)
 end
 
-"""
-    _getbit(pauli::Integer, bitindex::Integer)
 
-Gets the bit at index `bitindex` in the integer Pauli string.
-"""
+# Gets the bit at index `bitindex` in the integer Pauli string.
 function _getbit(pauli::Integer, bitindex::Integer)
     # return integer with ...000[bit].
 
@@ -192,11 +170,8 @@ function _getbit(pauli::Integer, bitindex::Integer)
     return shifted_pauli & typeof(pauli)(1)
 end
 
-"""
-    _setpaulibits(pstr::PauliStringType, pauli::PauliType, index::Integer)
 
-This function sets the Pauli at position `index` in the integer Pauli string to `target_pauli`.
-"""
+# This function sets the Pauli at position `index` in the integer Pauli string to `target_pauli`.
 function _setpaulibits(pstr::PauliStringType, target_pauli::PauliType, index::Integer)
     # we need to shift the integer by 2 * (index - 1), then the first two bits are target Pauli
     bitindex = 2 * (index - 1)
@@ -211,11 +186,8 @@ function _setpaulibits(pstr::PauliStringType, target_pauli::PauliType, index::In
     return pstr
 end
 
-"""
-    _setbit(pstr::PauliStringType, target_bit::Integer, bitindex::Integer)
 
-Sets a bit at index `bitindex` in the integer Pauli string to the value of `target_bit`.
-"""
+# Sets a bit at index `bitindex` in the integer Pauli string to the value of `target_bit`.
 function _setbit(pstr::PauliStringType, target_bit::Integer, bitindex::Integer)
     # set bit at bitindex to bit
 
@@ -227,11 +199,8 @@ function _setbit(pstr::PauliStringType, target_bit::Integer, bitindex::Integer)
     return pstr
 end
 
-"""
-    _setbittoone(pstr::Integer, bitindex::Integer)
 
-Sets a bit at index `bitindex` in the integer Pauli string to 1.
-"""
+# Sets a bit at index `bitindex` in the integer Pauli string to 1.
 function _setbittoone(pstr::Integer, bitindex::Integer)
     # set bit at bitindex to 1
 
@@ -243,11 +212,8 @@ function _setbittoone(pstr::Integer, bitindex::Integer)
 end
 
 
-"""
-    _setbittozero(pstr::Integer, bitindex::Integer)
 
-Sets a bit at index `bitindex` in the integer Pauli string to 0.
-"""
+# Sets a bit at index `bitindex` in the integer Pauli string to 0.
 function _setbittozero(pstr::Integer, bitindex::Integer)
     # set bit at bitindex to 0
 
@@ -263,6 +229,7 @@ function _setbittozero(pstr::Integer, bitindex::Integer)
 end
 
 
+# This mask helps us to parallelize the bit operations over all qubits.
 @generated function alternatingmask(pstr::T) where {T<:PauliStringType}
     # define our super bit mask looking like ....1010101.
 

--- a/src/PauliAlgebra/utils.jl
+++ b/src/PauliAlgebra/utils.jl
@@ -1,5 +1,5 @@
 # Defines mapping of integers 0, 1, 2, 3 to symbols :I, :X, :Y, :Z
-const pauli_symbols::Vector{Symbol} = [:I, :X, :Y, :Z]
+const pauli_symbols = (:I, :X, :Y, :Z)
 
 
 """

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -107,10 +107,6 @@ export
 
 include("truncations.jl")
 export
-    truncateweight,
-    truncatemincoeff,
-    truncatefrequency,
-    truncatesins,
     truncatedampingcoeff
 
 include("Propagation/Propagation.jl")

--- a/src/PauliTransferMatrix/matrices.jl
+++ b/src/PauliTransferMatrix/matrices.jl
@@ -92,17 +92,12 @@ const pauli_basis = [Idmat / sqrt(2), Xmat / sqrt(2), Ymat / sqrt(2), Zmat / sqr
 
 const _nqubit_pauli_matrices = Dict{Int,Vector{Matrix{ComplexF64}}}(1 => pauli_basis)
 
-"""
-    getpaulimatrices(nq::Int)
 
-Compute the Pauli basis for `n` qubits.
-
-Arguments
-- `n::Int`: The number of qubits.
-
-Returns
-- `basis::Vector{Array{ComplexF64}}`: The Pauli basis for `nq` qubits.
-"""
+# Compute the Pauli basis for `n` qubits.
+# Arguments
+# - `n::Int`: The number of qubits.
+# Returns
+# - `basis::Vector{Array{ComplexF64}}`: The Pauli basis for `nq` qubits.
 function getpaulibasis(nq::Int)
     if haskey(_nqubit_pauli_matrices, nq)
         return _nqubit_pauli_matrices[nq]

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -185,12 +185,9 @@ See the `4-custom-gates.ipynb` for examples of how to define custom gates.
 apply(gate::SG, pstr, coeff, theta; kwargs...) where {SG<:StaticGate} = apply(gate, pstr, coeff; kwargs...)
 
 ### MERGE
-"""
-    mergeandempty!(psum, aux_psum)
 
-Merge `aux_psum` into `psum` using the `merge` function. `merge` can be overloaded for different coefficient types.
-Then empty `aux_psum` for the next iteration.
-"""
+# Merge `aux_psum` into `psum` using the `merge` function. `merge` can be overloaded for different coefficient types.
+# Then empty `aux_psum` for the next iteration.
 function mergeandempty!(psum, aux_psum)
     # merge the smaller dict into the larger one
     if length(psum) < length(aux_psum)
@@ -203,31 +200,22 @@ function mergeandempty!(psum, aux_psum)
     return psum, aux_psum
 end
 
-"""
-    mergewith!(merge, psum::PauliSum{TermType, CoeffType}, aux_psum::PauliSum{TermType, CoeffType})
 
-Merge two `PauliSum`s using the `merge` function on the coefficients. `merge` can be overloaded for different coefficient types.
-"""
+# Merge two `PauliSum`s using the `merge` function on the coefficients. `merge` can be overloaded for different coefficient types.
 Base.mergewith!(merge, psum::PauliSum{TT,CT}, aux_psum::PauliSum{TT,CT}) where {TT,CT} = mergewith!(merge, psum.terms, aux_psum.terms)
 
-"""
-    merge(val1, val2)
 
-Merging two coefficients calls `+` by default unless there exists a suitable overloaded `merge` function.
-"""
+# Merging two coefficients calls `+` by default unless there exists a suitable overloaded `merge` function.
 function merge(coeff1, coeff2)
     return coeff1 + coeff2
 end
 
 
 ### TRUNCATE
-"""
-    checktruncationonall!(psum; max_weight::Real=Inf, min_abs_coeff=1e-10, max_freq::Real=Inf, max_sins::Real=Inf, kwargs...)
 
-Check truncation conditions on all Pauli strings in `psum` and remove them if they are truncated.
-This function supports the default truncations based on `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
-A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
-"""
+# Check truncation conditions on all Pauli strings in `psum` and remove them if they are truncated.
+# This function supports the default truncations based on `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
+# A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
 function checktruncationonall!(
     psum; max_weight::Real=Inf, min_abs_coeff=1e-10, max_freq::Real=Inf,
     max_sins::Real=Inf,
@@ -246,22 +234,16 @@ function checktruncationonall!(
     return
 end
 
-"""
-    checktruncationonone!(
-    psum, pstr, coeff;
-    max_weight::Real=Inf, min_abs_coeff=1e-10,
-    max_freq::Real=Inf, max_sins::Real=Inf,
-    customtruncfunc=nothing,
-    kwargs...
 
-Check truncation conditions one Pauli string in `psum` and it them if it is truncated.
-This function supports the default truncations based on `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
-A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
-"""
+# Check truncation conditions one Pauli string in `psum` and it them if it is truncated.
+# This function supports the default truncations based on `max_weight`, `min_abs_coeff`, `max_freq`, and `max_sins`.
+# A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
 @inline function checktruncationonone!(
     psum, pstr, coeff;
-    max_weight::Real=Inf, min_abs_coeff=1e-10,
-    max_freq::Real=Inf, max_sins::Real=Inf,
+    max_weight::Real=Inf,
+    min_abs_coeff=1e-10,
+    max_freq::Real=Inf,
+    max_sins::Real=Inf,
     customtruncfunc=nothing,
     kwargs...
 )

--- a/src/Surrogate/datatypes.jl
+++ b/src/Surrogate/datatypes.jl
@@ -1,13 +1,14 @@
-"""
-Abstract node type for the Pauli propagation Surrogate 
-"""
+###
+##
+# This file contains the types with which we represent the surrogate graph.
+##
+###
+
+# Abstract node type for the Pauli propagation Surrogate #
 abstract type CircuitNode end
 
-"""
-    EvalEndNode(pstr::Integer, coefficient::Real)
 
-Node type for the Pauli strings in the observable to be backpropagated.
-"""
+# Node type for the Pauli strings in the observable to be backpropagated.
 @kwdef mutable struct EvalEndNode <: CircuitNode
     pstr::Int
     coefficient::Float64
@@ -15,18 +16,12 @@ Node type for the Pauli strings in the observable to be backpropagated.
     is_evaluated::Bool = false
 end
 
-"""
-    EvalEndNode(pstr::Integer)
 
-Constructor for `EvalEndNode` with a default coefficient of 1.0.
-"""
+# Constructor for `EvalEndNode` with a default coefficient of 1.0.
 EvalEndNode(pstr::Integer) = EvalEndNode(pstr, 1.0)
 
-"""
-    PauliRotationNode(parents::Vector{Union{EvalEndNode,PauliRotationNode}}, trig_inds::Vector{Int}, signs::Vector{Int}, param_idx::Int)
 
-Surrogate graph node for a Pauli rotation gate.
-"""
+# Surrogate graph node for a Pauli rotation gate.
 @kwdef mutable struct PauliRotationNode <: CircuitNode
     parents::Vector{Union{EvalEndNode,PauliRotationNode}}
     trig_inds::Vector{Int}
@@ -36,20 +31,20 @@ Surrogate graph node for a Pauli rotation gate.
     is_evaluated::Bool = false
 end
 
-"""
-Pretty print for `CircuitNode`
-"""
+
+# Pretty print for `CircuitNode`
 Base.show(io::IO, node::CircuitNode) = print(io, "$(typeof(node))($(length(node.parents)) parent(s), param_idx=$(node.param_idx))")
-"""
-Pretty print for `EvalEndNode`
-"""
+
+# Pretty print for `EvalEndNode`
 Base.show(io::IO, node::EvalEndNode) = print(io, "$(typeof(node))(Pauli string=$(node.pstr), coefficient=$(node.coefficient))")
 
 ## PathProperties Type
 """
+    NodePathProperties(node::CircuitNode)
     NodePathProperties(node::CircuitNode, nsins::Int, ncos::Int, freq::Int)
 
 Surrogate `PathProperties` type. Carries `CircuitNode`s instead of numerical coefficients.
+If `nsins`, `ncos`, and `freq` are not provided, they are initialized to 0.
 """
 struct NodePathProperties <: PathProperties
     node::Union{EvalEndNode,PauliRotationNode}
@@ -58,17 +53,13 @@ struct NodePathProperties <: PathProperties
     freq::Int
 end
 
-"""
-Pretty print for PauliFreqTracker
-"""
+
+# Pretty print for PauliFreqTracker
 Base.show(io::IO, pth::NodePathProperties) = print(io, "NodePathProperties($(typeof(pth.node)), nsins=$(pth.nsins), ncos=$(pth.ncos), freq=$(pth.freq))")
 
 
-"""
-    NodePathProperties(node::CircuitNode)
 
-One-argument constructor for `NodePathProperties`. Initializes `nsins`, `ncos`, and `freq` to 0.
-"""
+# One-argument constructor for `NodePathProperties`. Initializes `nsins`, `ncos`, and `freq` to 0.
 NodePathProperties(node::CircuitNode) = NodePathProperties(node, 0, 0, 0)
 
 
@@ -116,13 +107,6 @@ function setcummulativevalue(node::CircuitNode, val)
     return
 end
 
-"""
-    set!(psum::Dict{TermType, NodePathProperties}, pstr::TermType, path::NodePathProperties)
-
-In-place setting the coefficient of a Pauli string in a Pauli sum dictionary.
-The type of the Pauli string needs to be the keytype=`TermType` of the dictionary, and the coefficient `coeff` needs to be the valuetype=`NodePathProperties`.
-If the coefficient is 0, the Pauli string is removed from the dictionary.
-"""
 function set!(psum::Dict{TT,NodePathProperties}, pstr::TT, path::NodePathProperties) where {TT}
     psum[pstr] = path
     return psum

--- a/src/Surrogate/propagate.jl
+++ b/src/Surrogate/propagate.jl
@@ -1,28 +1,24 @@
 ### Propagation necessities
 
 """
-    propagate(circ, pstr::PauliString{PauliStringType,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
+    propagate(circ, pstr::PauliString{<:Integer,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
 
 Construct a Pauli propagation surrogate of the propagated `PauliString` through the circuit `circ` in the Heisenberg picture. 
 The circuit must only contain `CliffordGate`s and `PauliRotation`s.
-It is applied to the Pauli string in reverse order, and the action of each gate is its conjugate action.
-Default truncations are `max_weight`, `max_freq`, and `max_sins`.
-A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
-Further `kwargs` are passed to the lower-level functions `applymergetruncate!`, `applytoall!`, `applyandadd!`, and `apply`.
+Truncations based on any numerical coefficient value cannot be used.
+Everything else is the same as in `propagate!()` for the non-Surrogate code.
 """
 function propagate(circ, pstr::PauliString{TT,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...) where {TT<:PauliStringType}
     return propagate(circ, PauliSum(pstr); max_weight, max_freq, max_sins, customtruncfunc, kwargs...)
 end
 
 """
-    propagate(circ, psum::PauliSum{PauliStringType,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
+    propagate(circ, psum::PauliSum{<:Integer,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
 
 Construct a Pauli propagation surrogate of the propagated `PauliSum` through the circuit `circ` in the Heisenberg picture.
 The circuit must only contain `CliffordGate`s and `PauliRotation`s. 
-It is applied to the Pauli sum in reverse order, and the action of each gate is its conjugate action.
-Default truncations are `max_weight`, `max_freq`, and `max_sins`.
-A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
-Further `kwargs` are passed to the lower-level functions `applymergetruncate!`, `applytoall!`, `applyandadd!`, and `apply`.
+Truncations based on any numerical coefficient value cannot be used.
+Everything else is the same as in `propagate!()` for the non-Surrogate code.
 """
 function propagate(circ, psum::PauliSum{TT,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...) where {TT<:PauliStringType}
     _checksurrogationconditions(circ)
@@ -30,16 +26,13 @@ function propagate(circ, psum::PauliSum{TT,NodePathProperties}; max_weight=Inf, 
 end
 
 """
-    propagate!(circ, psum::PauliSum{PauliStringType,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
+    propagate!(circ, psum::PauliSum{<:Integer,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...)
 
 Construct a Pauli propagation surrogate of the propagated `PauliSum` through the circuit `circ` in the Heisenberg picture. 
 The `PauliSum` `psum` is modified in place.
-The circuit must only contain `CliffordGate`s and `PauliRotation`s. 
-It is applied to the Pauli sum in reverse order, and the action of each gate is its conjugate action.
-The input `psum` will be modified.
-Default truncations are `max_weight`, `max_freq`, and `max_sins`.
-A custom truncation function can be passed as `customtruncfunc` with the signature customtruncfunc(pstr::PauliStringType, coefficient)::Bool.
-Further `kwargs` are passed to the lower-level functions `applymergetruncate!`, `applytoall!`, `applyandadd!`, and `apply`.
+The circuit must only contain `CliffordGate`s and `PauliRotation`s.
+Truncations based on any numerical coefficient value cannot be used.
+Everything else is the same as in `propagate!()` for the non-Surrogate code.
 """
 function propagate!(circ, psum::PauliSum{TT,NodePathProperties}; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing, kwargs...) where {TT<:PauliStringType}
     _checksurrogationconditions(circ)
@@ -101,11 +94,8 @@ end
 
 ## For Clifford Gates
 
-"""
-    apply(gate::CliffordGate, pstr::PauliStringType, coeff::NodePathProperties)
 
-Apply a `CliffordGate` to an integer Pauli string and `NodePathProperties` coefficient. 
-"""
+# Apply a `CliffordGate` to an integer Pauli string and `NodePathProperties` coefficient. 
 function apply(gate::CliffordGate, pstr::PauliStringType, coeff::NodePathProperties; kwargs...)
     # this array carries the new Paulis + sign for every occuring old Pauli combination
     map_array = clifford_map[gate.symbol]

--- a/src/numericalcertificates.jl
+++ b/src/numericalcertificates.jl
@@ -96,14 +96,9 @@ end
 
 # TODO: provide an easy way to just Monte Carlo sample paths. This will happen in a refactor.
 
-"""
-    montecarlopropagation(circ, pstr::PauliString, thetas, split_probabilities; max_weight=Inf, max_freq=Inf, max_sins=Inf)
-
-Perform a single Monte Carlo propagation of a Pauli string through an already reversed circuit. Returns the final Pauli string and a boolean indicating whether the path was truncated.
-
-It further assumes that the `thetas` and `split_probabilities` are already correctly calculated and provided as arguments. 
-In general they will be vectors, but they can also be real numbers.
-"""
+# Perform a single Monte Carlo propagation of a Pauli string through an already reversed circuit. Returns the final Pauli string and a boolean indicating whether the path was truncated.
+# It further assumes that the `thetas` and `split_probabilities` are already correctly calculated and provided as arguments. 
+# In general they will be vectors, but they can also be real numbers.
 function montecarlopropagation(circ, pstr::PauliString, thetas, split_probabilities; max_weight=Inf, max_freq=Inf, max_sins=Inf, customtruncfunc=nothing)
 
     param_idx = length(thetas)
@@ -150,21 +145,14 @@ end
 
 ## Monte Carlo apply functions
 
-"""
-    mcapply(gate::CliffordGate, pauli, coeff, theta, split_probability)
-
-`mcapply()` function for a `CliffordGate` is just the `apply()` function because it does not split.
-"""
+# `mcapply()` function for a `CliffordGate` is just the `apply()` function because it does not split.
 mcapply(gate::CliffordGate, pstr::PauliString, theta, split_probability) = PauliString(pstr.nqubits, apply(gate, pstr.term, pstr.coeff)...)
 
-"""
-    mcapply(gate::MaskedPauliRotation, pauli, coeff, theta, split_prob) 
 
-MC apply function for a `MaskedPauliRotation`.
-This will error if a `PauliRotation` is not converted to a `MaskedPauliRotation` before calling this function.
-If the gate commutes with the pauli string, the pauli string is left unchanged. 
-Else the pauli string is split off with a probability 1 - `split_prob`.
-"""
+# MC apply function for a `MaskedPauliRotation`.
+# This will error if a `PauliRotation` is not converted to a `MaskedPauliRotation` before calling this function.
+# If the gate commutes with the pauli string, the pauli string is left unchanged. 
+# Else the pauli string is split off with a probability 1 - `split_prob`.
 function mcapply(gate::MaskedPauliRotation, pstr::PauliString, theta, split_prob)
 
     if commutes(gate, pstr.term)
@@ -227,11 +215,10 @@ _incrementcosandfreq(val::Number) = val
 _incrementsinandfreq(val::Number) = val
 
 ## Utilities for `estimatemse()`
-"""
-Function that automatically calculates the vector of splitting probabilities of the gates in the circuit based on a vector of thetas.
-For Pauli gates, the theta value is interpreted as the limits of the integration [-theta, theta].
-For AmplitudeDampingNoise, the splitting probability is the damping rate.
-"""
+
+# Function that automatically calculates the vector of splitting probabilities of the gates in the circuit based on a vector of thetas.
+# For Pauli gates, the theta value is interpreted as the limits of the integration [-theta, theta].
+# For AmplitudeDampingNoise, the splitting probability is the damping rate.
 function _calculatesplitprobabilities(circ::AbstractArray, thetas::AbstractArray)
     if length(thetas) != countparameters(circ)
         throw("Vector `thetas` must have same length the number of parametrized gates in `circ`.")
@@ -249,10 +236,9 @@ function _calculatesplitprobabilities(circ::AbstractArray, thetas::AbstractArray
     return split_probabilities
 end
 
-"""
-Function that automatically calculates the splitting probability of the gates in the circuit based on a one number theta.
-This assumes that the circuit consists only of `PauliRotation` -`CliffordGate`.
-"""
+
+# Function that automatically calculates the splitting probability of the gates in the circuit based on a one number theta.
+# This assumes that the circuit consists only of `PauliRotation` -`CliffordGate`.
 function _calculatesplitprobabilities(circ::AbstractArray, r::Number)
     return 0.5 * (1 - sin(2 * r) / (2 * r))
 end

--- a/src/truncations.jl
+++ b/src/truncations.jl
@@ -1,96 +1,9 @@
-## TODO: Make actual use of this ile or remove.
-
-"""
-    truncateweight(pstr::PauliStringType, max_weight::Real)
-    
-Return `true` if an integer Pauli string should be truncated because its weight (i.e., number of non-identity Paulis) is larger than `max_weight`. 
-"""
-function truncateweight(pstr::PauliStringType, max_weight::Real)
-    return countweight(pstr) > max_weight
-end
-
-"""
-    truncatemincoeff(coeff, min_abs_coeff::Real)
-
-Return `true` if `abs(coeff) < min_abs_coeff`. Truncations on coefficients should default to false if it is not applicable for a type.
-"""
-function truncatemincoeff(coeff, min_abs_coeff::Real)
-    return false
-end
-
-"""
-    truncatemincoeff(coeff::Float64, min_abs_coeff::Real)
-
-Return `true` if `abs(coeff) < min_abs_coeff`. 
-"""
-function truncatemincoeff(coeff::Real, min_abs_coeff::Real)
-    return abs(coeff) < min_abs_coeff
-end
-
-
-"""
-    truncatemincoeff(path_property::PathProperties, min_abs_coeff::Real)
-
-Return `true` if `abs(path_property.coeff) < min_abs_coeff`. 
-"""
-function truncatemincoeff(path_property::PProp, min_abs_coeff::Real) where {PProp<:PathProperties}
-    if hasfield(PProp, :coeff)
-        return abs(path_property.coeff) < min_abs_coeff
-    else
-        return false
-    end
-end
-
-
-"""
-    truncatefrequency(coeff, max_freq::Real)
-
-Return `true` if  `PathProperties.freq > max_freq`. Truncations on coefficients should default to false if it is not applicable for a type.
-"""
-function truncatefrequency(coeff, max_freq::Real)
-    return false
-end
-
-"""
-    truncatefrequency(path_properties::PathProperties, max_freq::Real)
-
-Return `true` if  `path_properties.freq > max_freq`.
-"""
-function truncatefrequency(path_properties::PProp, max_freq::Real) where {PProp<:PathProperties}
-    if hasfield(PProp, :freq)
-        return path_properties.freq > max_freq
-    else
-        return false
-    end
-end
-
-"""
-    truncatesins(coeff, max_sins::Real)
-
-Return `true` if  `PathProperties.nsins > max_sins`. Truncations on coefficients should default to false if it is not applicable for a type.
-"""
-function truncatesins(coeff, max_sins::Real)
-    return false
-end
-"""
-    truncatesins(path_properties::PathProperties, max_sins::Real)
-
-Return `true` if  `path_properties.nsins > max_sins`.
-"""
-function truncatesins(path_properties::PProp, max_sins::Real) where {PProp<:PathProperties}
-    if hasfield(PProp, :nsins)
-        return path_properties.nsins > max_sins
-    else
-        return false
-    end
-end
-
 # Custom truncation function
 
 # Define the custom truncation functions by dissipation-assisted damping
 """
     truncatedampingcoeff(
-        pstr::PauliStringType, 
+        pstr::Integer, 
         coeff::Real, 
         gamma::Real, 
         min_abs_coeff::Float64
@@ -130,3 +43,70 @@ function truncatedampingcoeff(
 
     return abs(tonumber(coeff)) * 10.0^(-gamma * countweight(pstr)) < min_abs_coeff
 end
+
+
+## TODO: Make actual use of this file or remove.
+## from here on, the are just for the backend
+
+## Truncations on the Pauli string:
+
+# Return `true` if an integer Pauli string should be truncated because its weight (i.e., number of non-identity Paulis) is larger than `max_weight`. 
+function truncateweight(pstr::PauliStringType, max_weight::Real)
+    return countweight(pstr) > max_weight
+end
+
+
+## Truncations on the coefficient:
+
+# Truncations on unsuitable coefficient types defaults to false.
+function truncatemincoeff(coeff, min_abs_coeff::Real)
+    return false
+end
+
+
+# Return `true` if `abs(coeff) < min_abs_coeff`. 
+function truncatemincoeff(coeff::Real, min_abs_coeff::Real)
+    return abs(coeff) < min_abs_coeff
+end
+
+
+# Return `true` if `abs(path_property.coeff) < min_abs_coeff`. 
+function truncatemincoeff(path_property::PProp, min_abs_coeff::Real) where {PProp<:PathProperties}
+    if hasfield(PProp, :coeff)
+        return abs(path_property.coeff) < min_abs_coeff
+    else
+        return false
+    end
+end
+
+
+# Return `true` if  `PathProperties.freq > max_freq`. Truncations on coefficients should default to false if it is not applicable for a type.
+function truncatefrequency(coeff, max_freq::Real)
+    return false
+end
+
+
+# Return `true` if  `path_properties.freq > max_freq`.
+function truncatefrequency(path_properties::PProp, max_freq::Real) where {PProp<:PathProperties}
+    if hasfield(PProp, :freq)
+        return path_properties.freq > max_freq
+    else
+        return false
+    end
+end
+
+# Return `true` if  `PathProperties.nsins > max_sins`. Truncations on coefficients should default to false if it is not applicable for a type.
+function truncatesins(coeff, max_sins::Real)
+    return false
+end
+
+
+# Return `true` if  `path_properties.nsins > max_sins`.
+function truncatesins(path_properties::PProp, max_sins::Real) where {PProp<:PathProperties}
+    if hasfield(PProp, :nsins)
+        return path_properties.nsins > max_sins
+    else
+        return false
+    end
+end
+


### PR DESCRIPTION
These changes are mainly to adapt the docstrings, i.e., whether they exist or not, to whether users are supposed to interact with the function. This should help with automatically generating docstrings.

Actual changes:
- IMPORTANT: Added `*` product between `PauliString`s and `PauliSum`s! THIS STILL NEEDS TESTS!
- We no longer export most functions from `truncations.jl`, because they are only backend functions with trivial effectis. This begs the question of what to do with this file.