### PR TITLE
re-use README in site doc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,6 +66,12 @@ jobs:
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
 
+      # symlink repo README to 'docs/src/index.md'
+      # as needed by subsequent doc generation
+      - name: Setup symlink
+        run: ln -s ../../README.md index.md
+        working-directory: docs/src
+
       - name: Build and deploy
         run: julia --color=yes --project=docs docs/make.jl
         env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -86,6 +86,10 @@ jobs:
     # perform this after doc regen
     needs: build-doc
 
+    # only cleanup when main is pushed, preserving all the
+    # working clones of the doc (like from PRs) in the meantime
+    if: github.event_name == 'push' && github.ref_name == 'main'
+
     steps:
 
       - name: Checkout gh-pages branch

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,10 +8,12 @@ name: Documentation
 
 # Regenerate doc (updating Github Pages site) whenever...
 on:
-  # main is updated (updates root site with new release)
+  # main is updated (updates root site with new release), or
+  # dev is updated (updates /dev/ subdomain)
   push:
     branches:
       - main
+      - dev
   # a PR is opened to the below branches (updates /previews/PR#)
   pull_request:
     branches:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,15 @@
 # Generates HTML documentation from the contents of
-# the docs folder, triggered locally by command
-#   julia --project make.jl
+# the docs folder. To generate, we must first setup
+# a symlink from the repo README.md to src/index.md,
+# in order re-use the README in Documenter.jl
+# From the docs/ directory (containing this file):
+#     cd src
+#     ln -s ../../README.md index.md
+#     cd ../
+#
+# This need only be done once per-machine. Then,
+# generating/updating the doc is triggered via
+#     julia --project make.jl
 # 
 # If triggered within a Github Action, the generated
 # HTML files will then be committed to the 'gh-pages'
@@ -11,6 +20,8 @@
 # will be uploaded to subdomain /dev/, even when not
 # from the 'dev' branch, and doc generated from pull
 # requests will be uploaded to /previews/PR#.
+#
+# If this breaks, break Tyson's legs
 
 
 using Documenter, PauliPropagation
@@ -22,9 +33,22 @@ makedocs(
 
     # determines site layout
     pages=[
-        "index.md",
+
+        # index.md does not exist; it is a symlink
+        # to the repo's README.md file, created as
+        # per the comments above, to avoid duplicating
+        # the README.md contents into Documenter.jl 
+        # pages. We manually override its name in the
+        # left navbar to be "Introduction"
+        "Introduction" => "index.md",
+
+        # these other 'top-level' files DO exist, and
+        # have names inferred from their section names
         "installation.md",
         "tutorials.md",
+
+        # these 'lower-level' files also exist, and will
+        # be grouped under an 'API' section in the navbar
         "API" => [
             "api/Circuits.md",
             "api/Gates.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -82,4 +82,8 @@ deploydocs(
 # - msrudolph.github.io/PauliPropagation.jl/
 # - msrudolph.github.io/PauliPropagation.jl/dev/
 # - msrudolph.github.io/PauliPropagation.jl/previews/PR#
-# where # above is replaced with the pull request number
+# where # above is replaced with the pull request number.
+#
+# These "doc clones" are deleted whenever a commit is pushed to the main
+# branch (signifying a version release), so that development history does
+# not bloat the repo. Deletion is performed by the 'tidy-doc' CI job.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,0 @@
-# Introduction
-
-> TODO


### PR DESCRIPTION
via symbolically linking a fictitious 'index.md' to the main README.md. This mischief is necessary since Documenter.jl cannot process files above its working directory.

See here for more info:
https://github.com/JuliaDocs/Documenter.jl/issues/551