### PR TITLE
attempt to fix preview-doc of dev branch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -79,7 +79,11 @@ deploydocs(
     # Enable generation of doc from PRs, under a /previews/PR## sub-domain.
     # Beware that this requires the Github Action was explicitly triggered by
     # a 'pull_request' event (not a 'push')
-    push_preview=true
+    push_preview=true,
+
+    # Specify the name of our develop branch (Documenter.jl seems unable to 
+    # auto-infer it) so that changes thereto generate preview-documentation 
+    devbranch="dev"
 )
 
 


### PR DESCRIPTION
The `deploydocs` [doc](https://documenter.juliadocs.org/stable/lib/public/#Documenter.deploydocs) includes:

> **`devbranch`** is the branch that "tracks" the in-development version of the generated
> documentation. By default Documenter tries to figure this out using `git`. Can be set
> explicitly as a string (typically `"master"` or `"main"`).

The examples of `"main"` seem highly misleading for an "in-development" version which is by default deployed to:
> **`devurl`** the folder that in-development version of the docs will be deployed. Defaults to "dev".

Despite the doc claiming Documenter "tries to figure this out using `git`", it's possible this is failing for our in-development branch called `"dev`". The [CI](https://github.com/MSRudolph/PauliPropagation.jl/actions/runs/15215090657/job/42798589972) launched by a push to `dev`  did not publish to `devurl` because:

```
┌ Info: Deployment criteria for deploying devbranch build from GitHub Actions:
│ - ✘ ENV["GITHUB_REF"] matches devbranch="main"
```

That is, `devbranch` defaulted to `"main"`. This remains such an extremely strange choice of default in-development branch that I cannot help but wonder if explicitly setting `devbranch="dev"` is going to break generation of doc on `main`! :^)
