### PR TITLE
generate main doc upon versioned release

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,18 +8,29 @@ name: Documentation
 
 # Regenerate doc (updating Github Pages site) whenever...
 on:
-  # main is updated (updates root site with new release), or
-  # dev is updated (updates /dev/ subdomain)
   push:
+
+    # 'dev' is updated (updates /dev/ subdomain). Note we cannot
+    # simply add other branchces (like 'main') here because it must
+    # correspond to 'devbranch' passed to deploydocs() in make.jl,
+    # else the generated doc will not be published to gh-pages
     branches:
-      - main
       - dev
-  # a PR is opened to the below branches (updates /previews/PR#)
+
+    # a new release tag is created. Only releases with semantic
+    # versioning tags of the form 'vX.Y.Z' will be published to 
+    # gh-pages, updating subdomains /stable/ and /vX.Y.Z/. This
+    # is further constrained by the 'versions' arg to deploydocs()
+    tags: '*'
+
+  # a PR is opened to the below branches (updates /previews/PR# subdomain)
   pull_request:
     branches:
       - main
       - dev
-  # the workflow is manually triggered from the Actions tab (updates /dev/)
+
+  # the workflow is manually triggered in the Github Actions tab, using
+  # the dev branch (updates /dev/). 
   workflow_dispatch:
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -71,8 +71,8 @@ makedocs(
 )
 
 
-# When run from a Github Action, commit those files to the 'gh-pages' branch.
-# If the action's invoking branch is not main, the files are uploaded under /dev/
+# When run from a Github Action, commit those files to the 'gh-pages' branch,
+# depending upon the triggering branch or whether it is a release/pull-request.
 deploydocs(
     repo="github.com/MSRudolph/PauliPropagation.jl.git",
 
@@ -81,9 +81,21 @@ deploydocs(
     # a 'pull_request' event (not a 'push')
     push_preview=true,
 
-    # Specify the name of our develop branch (Documenter.jl seems unable to 
-    # auto-infer it) so that changes thereto generate preview-documentation 
-    devbranch="dev"
+    # Specify that changes to our 'dev' branch (rather than default 'main')
+    # should update the doc visible at the /dev/ sub-domain. Note this means
+    # pushes to the main branch never generate doc; only new releases will
+    # (see below)
+    devbranch="dev",
+    devurl="dev",
+
+    # Control which Github releases (here, all) trigger re-generation of the
+    # main documentation, and their URLs. Below, we specify that:
+    # - subdomain /stable/ presents the very latest release doc
+    # - all versions (including patches) have their own hosted doc under /vX.Y.Z/
+    # - changes to the dev branch should update the /dev/ sub-domain; this seems
+    #   gratuitous since specified above and since irrelevant to Github releases,
+    #   but it is present in the deploydocs() doc without elaboration. Grr!
+    versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"]
 )
 
 


### PR DESCRIPTION
by triggering CI when a new tag is pushed, and ensuring Documenter.jl publishes the resulting doc