### PR TITLE
Dictionaries.jl optimized for PauliRotations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,18 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[weakdeps]
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+
 [compat]
 BitIntegers = "0.3"
 Bits = "0.2"
+Dictionaries = "0.4.5"
 StatsBase = "0.34"
 julia = "1.6.7"
+
+[extensions]
+DictPauliPropagationExt = "Dictionaries"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ext/DictPauliPropagationExt.jl
+++ b/ext/DictPauliPropagationExt.jl
@@ -1,0 +1,42 @@
+module DictPauliPropagationExt
+
+using Dictionaries
+using Dictionaries: Dictionary
+import PauliPropagation
+import PauliPropagation: applytoall!, PauliRotation, _tomaskedpaulirotation, getnewpaulistring, commutes,sizehint!
+
+using Dictionaries: Dictionary, 
+                   istokenizable,
+                   tokens,
+                   gettokenvalue,
+                   settokenvalue!,
+                   haskey,
+                   insert!,
+                   pairs
+
+function PauliPropagation.applytoall!(gate::PauliRotation, theta, psum::Dictionary{K,V}, aux_psum::Dictionary{K,V}) where {K,V}
+    gate = _tomaskedpaulirotation(gate, K)
+    cos_val = cos(theta)
+    sin_val = sin(theta)
+    to_update = Vector{K}()
+    new_terms = Vector{Tuple{K,V}}()
+    for (pstr, coeff) in pairs(psum)
+        if commutes(gate, pstr)
+            continue
+        end
+        push!(to_update, pstr)
+        new_pstr, sign = getnewpaulistring(gate, pstr)
+        push!(new_terms, (new_pstr, coeff * sin_val * sign))
+    end
+    for pstr in to_update
+        psum[pstr] = psum[pstr] * cos_val
+    end
+    for (new_pstr, new_coeff) in new_terms
+        if haskey(aux_psum, new_pstr)
+            aux_psum[new_pstr] += new_coeff
+        else
+            insert!(aux_psum, new_pstr, new_coeff)
+        end
+    end
+end
+end

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -47,6 +47,23 @@ function applytoall!(gate::PauliRotation, theta, psum, aux_psum; kwargs...)
 
     return
 end
+function applytoall!(gate::PauliRotation, theta, psum::Dict{K,V}, aux_psum::Dict{K,V}; kwargs...) where {K,V}
+    gate = _tomaskedpaulirotation(gate, K)
+    cos_val = cos(theta)
+    sin_val = sin(theta)
+    for (pstr, coeff) in psum
+        if commutes(gate, pstr)
+            continue
+        end
+        coeff1 = coeff * cos_val
+        new_pstr, sign = getnewpaulistring(gate, pstr)
+        coeff2 = coeff * sin_val * sign
+        set!(psum, pstr, coeff1)
+        set!(aux_psum, new_pstr, coeff2)
+    end
+    return
+end
+
 
 """
     getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)


### PR DESCRIPTION
## Benchmark Results: Dictionary.jl vs Base.Dict for PauliRotation Gates
### Overview

This PR with regards to #87  presents benchmark results comparing `Dictionaries.jl`and `Base.Dict `performance for `PauliRotation` gate applications at large scales. The results might help inform our decision about whether to adopt `Dictionaries.jl` for our core operations.

### Implementation

I've implemented `Dictionaries.jl` backend via the extension just for the purpose of this PR and dispatched on `applytoall!` for` PauliRotations` to check whether the `Dictionaries` are not slower that `Base.dict`. I am testing the large instances that take some minutes and will update the results in a while as well.

```julia
function PauliPropagation.applytoall!(gate::PauliRotation, theta, psum::Dictionary{K,V}, aux_psum::Dictionary{K,V}) where {K,V}
    # Specialized implementation
end
```

### Benchmarks

```julia
julia> using Printf

julia> using Test

julia> using Dictionaries

julia> using BenchmarkTools

julia> using PauliPropagation

julia> import Base: merge

julia> using Statistics

julia> function benchmarks()
           cases = [
                ("(5q, 1k)", 5, 1000),
                ("(10q, 10k)", 10, 10000), 
                ("(20q, 50k)", 20, 50000),
                ("(25q, 100k)", 25, 100000),
                ("(30q, 500k)", 30, 500000),
                ("(20q, 1M)", 20, 1_000_000),
                ("(25q, 5M)", 25, 5_000_000),
                ("(30q, 10M)", 30, 10_000_000),
                # ("(40q, 50M)", 40, 50_000_000),
                # ("(50q, 100M)", 50, 100_000_000)
           ]
     results = []
    
    for (desc, nq, nt) in cases
        @info "Running benchmark for $desc case"
        
        # Create test data with unique keys
        terms_dict = Dict{Int, Float64}()
        while length(terms_dict) < nt
            terms_dict[rand(1:4^nq-1)] = randn()
        end
        terms_dictjl = Dictionary(terms_dict)
        
        gate = PauliRotation(rand([:X, :Y, :Z], nq), 1:nq)
        theta = randn()
        
        # Verification phase (runs once before benchmarking)
        let
            dict_result = let
                psum = deepcopy(terms_dict)
                aux = Dict{keytype(psum),valtype(psum)}()
                applytoall!(gate, theta, psum, aux)
                merge(psum, aux)
            end
            
            dictjl_result = let
                psum = deepcopy(terms_dictjl)
                aux = Dictionary{keytype(psum),valtype(psum)}()
                applytoall!(gate, theta, psum, aux)
                merge(psum, aux)
            end
            
            # Detailed consistency checks
            @assert length(dict_result) == length(dictjl_result)
            for (k,v) in dict_result
                @assert haskey(dictjl_result, k)
                @assert v ≈ dictjl_result[k] rtol=1e-10
            end
            @info "Consistency check passed for $desc"
        end
        
        # Benchmark phase
        t_dict = @belapsed begin
            psum = $(deepcopy(terms_dict))
            aux = Dict{keytype(psum),valtype(psum)}()
            applytoall!($gate, $theta, psum, aux)
        end samples=5 evals=1
        
        t_dictjl = @belapsed begin
            psum = $(deepcopy(terms_dictjl))
            aux = Dictionary{keytype(psum),valtype(psum)}()
            applytoall!($gate, $theta, psum, aux)
        end samples=5 evals=1
        
        # Memory measurement
        mem_dict = @allocated begin
            psum = deepcopy(terms_dict)
            aux = Dict{keytype(psum),valtype(psum)}()
            applytoall!(gate, theta, psum, aux)
        end
        
        mem_dictjl = @allocated begin
            psum = deepcopy(terms_dictjl)
            aux = Dictionary{keytype(psum),valtype(psum)}()
            applytoall!(gate, theta, psum, aux)
        end
        
        push!(results, (
            desc, nq, nt, 
            t_dict, t_dictjl,
            mem_dict/2^20, mem_dictjl/2^20  # Convert to MB
        ))
    end
    
    return results
end


julia> function display_results(results)
           println("\nBenchmark Results:")
           println("="^120)
           println("Case               | Qubits | Terms      | Dict Time (s) | Dict.jl Time (s) | Dict Mem (GB) | Dict.jl Mem (GB)")
           println("="^120)
           for (desc, nq, nt, t_dict, t_dictjl, mem_dict, mem_dictjl) in results
               @printf("%-18s | %6d | %10d | %12.3f | %15.3f | %12.3f | %15.3f\n",
                       desc, nq, nt, 
                       t_dict, t_dictjl,
                       mem_dict, mem_dictjl)
           end
           println("="^120)
       end
display_results (generic function with 1 method)


julia> @info "Starting benchmarks..."
julia>  GC.gc()  # Clean up before starting
julia> results = benchmarks()
julia>  display_results(results)
```

Edit: Recent results

```julia

julia> results = benchmarks()
[ Info: Running benchmark for (5q, 1k) case
[ Info: Consistency check passed for (5q, 1k)
[ Info: Running benchmark for (10q, 10k) case
[ Info: Consistency check passed for (10q, 10k)
[ Info: Running benchmark for (20q, 50k) case
[ Info: Consistency check passed for (20q, 50k)
[ Info: Running benchmark for (25q, 100k) case
[ Info: Consistency check passed for (25q, 100k)
[ Info: Running benchmark for (30q, 500k) case
[ Info: Consistency check passed for (30q, 500k)
[ Info: Running benchmark for (20q, 1M) case
[ Info: Consistency check passed for (20q, 1M)
[ Info: Running benchmark for (25q, 5M) case
[ Info: Consistency check passed for (25q, 5M)
[ Info: Running benchmark for (30q, 10M) case
[ Info: Consistency check passed for (30q, 10M)
8-element Vector{Any}:
 ("(5q, 1k)", 5, 1000, 4.9352e-5, 4.1825e-5, 0.0894012451171875, 0.11883544921875)
 ("(10q, 10k)", 10, 10000, 0.000656545, 0.000595507, 0.6208343505859375, 1.337493896484375)
 ("(20q, 50k)", 20, 50000, 0.004842107, 0.004266234, 5.6678009033203125, 6.888427734375)
 ("(25q, 100k)", 25, 100000, 0.011905444, 0.011084107, 9.917892456054688, 14.30267333984375)
 ("(30q, 500k)", 30, 500000, 0.066036702, 0.065690405, 31.167984008789062, 65.20733642578125)
 ("(20q, 1M)", 20, 1000000, 0.110951165, 0.103245656, 65.16807556152344, 130.5728759765625)
 ("(25q, 5M)", 25, 5000000, 0.651993321, 0.787818431, 269.1682586669922, 699.9205627441406)
 ("(30q, 10M)", 30, 10000000, 1.555059151, 1.810584953, 541.1683502197266, 1399.9919738769531)

julia> display_results(results)

Benchmark Results:
========================================================================================================================
Case               | Qubits | Terms      | Dict Time (s) | Dict.jl Time (s) | Dict Mem (GB) | Dict.jl Mem (GB)
========================================================================================================================
(5q, 1k)           |      5 |       1000 |        0.000 |           0.000 |        0.089 |           0.119
(10q, 10k)         |     10 |      10000 |        0.001 |           0.001 |        0.621 |           1.337
(20q, 50k)         |     20 |      50000 |        0.005 |           0.004 |        5.668 |           6.888
(25q, 100k)        |     25 |     100000 |        0.012 |           0.011 |        9.918 |          14.303
(30q, 500k)        |     30 |     500000 |        0.066 |           0.066 |       31.168 |          65.207
(20q, 1M)          |     20 |    1000000 |        0.111 |           0.103 |       65.168 |         130.573
(25q, 5M)          |     25 |    5000000 |        0.652 |           0.788 |      269.168 |         699.921
(30q, 10M)         |     30 |   10000000 |        1.555 |           1.811 |      541.168 |        1399.992
========================================================================================================================

```


### Addiional Context
Tests pass locally so nothing is broken by the changes
```julia
     Testing Running tests...
Test Summary:       | Pass  Total   Time
PauliPropagation.jl |  290    290  46.8s
     Testing PauliPropagation tests passed 
```

Consistency check between `Base.dict` and `Dictionary`, Before bench marking, the consistency checks runs
```
julia> function benchmark_comparison()
               # same code as above code
                   # Detailed consistency checks
                   @assert length(dict_result) == length(dictjl_result)
                   for (k,v) in dict_result
                       @assert haskey(dictjl_result, k)
                       @assert v ≈ dictjl_result[k] rtol=1e-10
                   end
                   @info "Consistency check passed for $desc"
               end
          # remaining code
       end
```

I am reading the `Dictionaries.jl` API for better understanding of any more optimizations that can be done.
