### PR TITLE
Add bitwise sign calculation for pauliprod improving performance

### DIFF
--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -55,7 +55,7 @@ Get the new Pauli string after applying a `MaskedPauliRotation` to an integer Pa
 as well as the corresponding ±1 coefficient.
 """
 function getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)
-    new_pstr, sign = pauliprod(gate.generator_mask, pstr, gate.qinds)
+    new_pstr, sign = pauliprod(gate.generator_mask, pstr)
     return new_pstr, real(1im * sign)
 end
 


### PR DESCRIPTION
Added a bitwise implementation for pauli product sign computation, replacing the levi-cevita lookup table.  This implementation removes the need for checking the changed indices and has most of its overhead from exponentiating the imaginary unit.  It is implemented in such a way that the exponent itself can be calculated to save this overhead in hot loops where it may not be necessary to do the exponentiation each time.

The performance improvement can be seen from running the below code.

```
using BenchmarkTools, PauliPropagation

pstr1_dense = PauliString(128, rand([:I,:X,:Y,:Z], 128), 1:128)
pstr2_dense = PauliString(128, rand([:I,:X,:Y,:Z], 128), 1:128)

pstr1_sparse = PauliString(128, :X, 64)
pstr2_sparse = PauliString(128, :Z, 64)

@benchmark pauliprod($pstr1_dense, $pstr2_dense)
@benchmark pauliprod($pstr1_sparse, $pstr2_sparse)
```

The performance of my implementation is as follows (run on my laptop):
```
(dense)
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  26.923 ns … 54.588 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     26.967 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   27.077 ns ±  0.540 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▅▃▂▁▁▂▂▂▂                                                 ▂
  ████████████▅▁▁▁▁▃▁▁▁▃▁▁▁▁▁▁▁▃▁▁▃▁▄▃▁▁▃▄▃▁▁▁▁▃▁▁▅▄▃▆▇██▇▇▆▅ █
  26.9 ns      Histogram: log(frequency) by time      29.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
```
(sparse)
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  28.755 ns … 76.436 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     29.051 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   29.173 ns ±  0.949 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▁      ▂                                                    
  ██▅▃▃▃▄▇█▇▄▃▂▁▂▂▁▁▂▁▂▁▁▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  28.8 ns         Histogram: frequency by time        32.3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

The performance of the old version is as follows:
```
(dense)
BenchmarkTools.Trial: 10000 samples with 9 evaluations.
 Range (min … max):  2.263 μs …  5.436 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.299 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.307 μs ± 65.491 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▂▆█▇▇▇▇▂                                                  
  ▂▄████████▆▃▃▂▂▂▂▁▁▂▁▁▂▂▂▂▂▁▂▂▁▁▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂ ▃
  2.26 μs        Histogram: frequency by time         2.6 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
```
(sparse)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.147 μs …  3.151 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.165 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.169 μs ± 37.942 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▅██▄                                                      
  ▂▆████▇▄▃▂▂▂▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▁▁▁▁▂▁▁▁▁▂▂▂▁▂▂▂▂ ▃
  1.15 μs        Histogram: frequency by time        1.42 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

I have verified that all tests are passing.  Please let me know if any changes are needed.