### PR TITLE
Add bitwise sign calculation for pauliprod improving performance

### DIFF
--- a/src/PauliAlgebra/paulioperations.jl
+++ b/src/PauliAlgebra/paulioperations.jl
@@ -293,10 +293,12 @@ function _calculatesignexponent(pauli1::PauliType, pauli2::PauliType)
     # 01 |--|--|T |F |
     # 11 |--|F |--|T |
     # 10 |--|T |F |--|
-    negative_sign = not_commuting & ((~pauli1_2 & ~pauli2_1) 
-                                     | (pauli1_2 & pauli2_1 & pauli2_2) 
-                                     | (pauli1_1 & pauli1_2 & pauli2_1))
-    positive_sign = (~negative_sign) & not_commuting
+    # which gives (a & ~d) | (~a & d) | (~b & ~c)
+    # you can then recognize that (a & ~d) | (~a & d) = a ⊻ b
+    # where pauli1 = ab, and pauli2 = cd.
+    negative_sign = not_commuting & ((pauli1_1 ⊻ pauli2_2) 
+                                     | (~pauli1_2 & ~pauli2_1))
+    positive_sign = not_commuting & (~negative_sign) 
     # You can use modular addition to achieve addition of the exponent,
     # since it is cyclic, and the global phase can be determined by the number
     # of 1's in each expression.

--- a/src/PauliAlgebra/paulioperations.jl
+++ b/src/PauliAlgebra/paulioperations.jl
@@ -261,7 +261,7 @@ Calculate the product of two integer Pauli strings.
 function pauliprod(pstr1::PauliStringType, pstr2::PauliStringType)
     # This function is for when we need to globally check the sign of the product (like in general products of Paulis, not local Pauli gates)
     pstr3 = _bitpaulimultiply(pstr1, pstr2)
-    sign = im ^ _calculatesignexponent(pstr1, pstr2)
+    sign = _impow(_calculatesignexponent(pstr1, pstr2))
     return pstr3, sign
 end
 
@@ -304,4 +304,11 @@ function _calculatesignexponent(pauli1::PauliType, pauli2::PauliType)
     # of 1's in each expression.
     # i.e. -im = im^(3); im = im^(1); 1 = im^0.  
     return ((3 * count_ones(negative_sign) + count_ones(positive_sign)) % 4)
+end
+
+#speeds up pauliprod by a factor of 2 since we know we only want integer powers
+const  impowers = [1, im, -1, -im]
+function _impow(power::Integer)
+    ind = (power % 4) + 1
+    return impowers[ind]
 end

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -55,8 +55,10 @@ Get the new Pauli string after applying a `MaskedPauliRotation` to an integer Pa
 as well as the corresponding ±1 coefficient.
 """
 function getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)
-    new_pstr, sign = pauliprod(gate.generator_mask, pstr)
-    return new_pstr, real(1im * sign)
+    new_pstr = _bitpaulimultiply(gate.generator_mask, pstr)
+    im_count = _calculatesignexponent(gate.generator_mask, pstr)
+    sign = (im_count & 2) - 1
+    return new_pstr, sign
 end
 
 

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -55,7 +55,7 @@ Get the new Pauli string after applying a `MaskedPauliRotation` to an integer Pa
 as well as the corresponding ±1 coefficient.
 """
 function getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)
-    new_pstr, sign = pauliprod(gate.generator_mask, pstr, gate.qinds)
+    new_pstr, sign = pauliprod(gate.generator_mask, pstr)
     return new_pstr, real(1im * sign)
 end
 

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -48,16 +48,18 @@ function applytoall!(gate::PauliRotation, theta, psum, aux_psum; kwargs...)
     return
 end
 
-"""
-    getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)
 
-Get the new Pauli string after applying a `MaskedPauliRotation` to an integer Pauli string,
-as well as the corresponding ±1 coefficient.
-"""
 function getnewpaulistring(gate::MaskedPauliRotation, pstr::PauliStringType)
     new_pstr = _bitpaulimultiply(gate.generator_mask, pstr)
+
+    # this counts the exponent of the imaginary unit in the new Pauli string
     im_count = _calculatesignexponent(gate.generator_mask, pstr)
+
+    # now, instead of computing im^im_count followed by another im factor from the gate rules,
+    # we do this in one step via a cheeky trick:
     sign = (im_count & 2) - 1
+    # this is equivalent to sign = real( im * im^im_count)
+
     return new_pstr, sign
 end
 


### PR DESCRIPTION
Added a bitwise implementation for pauli product sign computation, replacing the levi-cevita lookup table. This implementation removes the need for checking the changed indices and has most of its overhead from exponentiating the imaginary unit. It is implemented in such a way that the exponent itself can be calculated to save this overhead in hot loops where it may not be necessary to do the exponentiation each time.

The performance improvement can be seen from running the below code.
```
using BenchmarkTools, PauliPropagation

pstr1_dense = PauliString(128, rand([:I,:X,:Y,:Z], 128), 1:128)
pstr2_dense = PauliString(128, rand([:I,:X,:Y,:Z], 128), 1:128)

pstr1_sparse = PauliString(128, :X, 64)
pstr2_sparse = PauliString(128, :Z, 64)

@benchmark pauliprod($pstr1_dense, $pstr2_dense)
@benchmark pauliprod($pstr1_sparse, $pstr2_sparse)
```
The performance of my implementation is as follows (run on my laptop):

```
(dense)
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  23.383 ns … 128.074 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     23.412 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   24.009 ns ±   2.546 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅      ▂▁                      ▂                            ▁
  ██▅▇▇▆▅▆██▆▅▅▅▃▄▆▅▅▅▆▇▅▅▅▅▄▅▆▅▅▅█▇▅▅▅▆▅▆▅▅▅▅█▆▃▂▃▄▄▄▃▄▄▃▂▄▃▄ █
  23.4 ns       Histogram: log(frequency) by time      32.9 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
```
(sparse)
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  15.804 ns … 35.685 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     16.430 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   16.741 ns ±  1.194 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      █▅▆▇▄    ▁  ▁                        ▂  ▁▁         ▁    ▁
  ▇▅▆▂█████▆▅▄▅██▆██▇▇▇█▇▆▆▅▅▅▅▅▅▅▅▅▅▆▄▅▆▅▅██▇██▅▆▆▆▄▅▅▆▅█▆▆█ █
  15.8 ns      Histogram: log(frequency) by time      21.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Old Version
```
(dense)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.278 μs …   2.985 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.300 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.332 μs ± 103.455 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄███▇▄     ▁ ▁                                 ▁ ▁▁▁     ▁  ▂
  ███████▆▅▄▇████▆▄▄▅▅▄▇▇█▇▆▅▆▅▅▅▄▅▅▅▅▄▃▃▅▅▄▅▄▄▄▇█████▇▆█████ █
  1.28 μs      Histogram: log(frequency) by time      1.71 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
```
(sparse no index)
BenchmarkTools.Trial: 10000 samples with 165 evaluations.
 Range (min … max):  645.000 ns …  1.111 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     656.742 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   671.659 ns ± 44.945 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃▇██▇▅▄▂                                                     ▂
  ██████████▇█▇█▇▇▇▇▇▇▆▆▅▇▇▇▇▇█▇█▇▇▇████▇███████▇███▇█▇▆▅▅▅▆▄▅ █
  645 ns        Histogram: log(frequency) by time       852 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
```
(sparse with index)
@benchmark pauliprod($pstr1_sparse.term, $pstr2_sparse.term, 64)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  6.699 ns … 12.710 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.759 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.910 ns ±  0.508 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▇█▆▆▄▂    ▂▂                                   ▂▁     ▁▁   ▂
  ██████▇▇▄▆█████▅▃▃▄▄▅▆▅▅▅▃▅▄▄▄▁▁▄▅▅▃▃▅▅▇██▆▆▄▄███▇▆▇▆▅████ █
  6.7 ns       Histogram: log(frequency) by time     8.86 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Note that this does degrade performance slightly for instances where the index is known, but it is small compared to the general case.  This is also a duplicate of #104, just submitted from a branch on this repository, rather than a fork.