### PR TITLE
Update version support information to match LTS, specify Base kwargs …

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,13 +20,13 @@ Bits = "0.2"
 JSON = "0.21.4"
 PlotGraphviz = "0.6.3"
 StatsBase = "0.34"
-Test = "1.11.0"
-UUIDs = "1.11.0"
-julia = "1.6.7"
+Test = "1.10"
+UUIDs = "1.10"
+julia = "1.10"
 
 [extras]
-Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 
 [targets]
 test = ["Yao", "Test"]

--- a/src/Surrogate/datatypes.jl
+++ b/src/Surrogate/datatypes.jl
@@ -9,7 +9,7 @@ abstract type CircuitNode end
 
 
 # Node type for the Pauli strings in the observable to be backpropagated.
-@kwdef mutable struct EvalEndNode <: CircuitNode
+Base.@kwdef mutable struct EvalEndNode <: CircuitNode
     pstr::Int
     coefficient::Float64
     cummulative_value::Float64 = 0.0
@@ -22,7 +22,7 @@ EvalEndNode(pstr::Integer) = EvalEndNode(pstr, 1.0)
 
 
 # Surrogate graph node for a Pauli rotation gate.
-@kwdef mutable struct PauliRotationNode <: CircuitNode
+Base.@kwdef mutable struct PauliRotationNode <: CircuitNode
     parents::Vector{Union{EvalEndNode,PauliRotationNode}}
     trig_inds::Vector{Int}
     signs::Vector{Int}


### PR DESCRIPTION
This pull request fixes some versioning issues that came from the version specified for Test and UUIDs, which needed to match the Julia version.  It also updates the minimum version of Julia to the LTS, version 10.  This is necessary since this package fails tests on version 1.6.7 (any version under 1.9.0 actually), so it ensures valid execution for users.

I also specified Base.@kwargs, since this caused issues in older versions of Julia.  Arguably this fix is pointless, since it is captured by the version upgrading, but it doesn't hurt to be more explicit to help the compiler.