### PR TITLE
Convert the coefficient types for PauliString and PauliSum

### DIFF
--- a/src/PauliAlgebra/utils.jl
+++ b/src/PauliAlgebra/utils.jl
@@ -293,38 +293,37 @@ function _getprettystr(psum::Dict, nqubits::Int; max_lines=20)
 end
 
 
-# Convert the a Pauli String to a different coefficient type
-"""
-    converttype(ctype::Type, pstr::PauliString)
-
-Convert a `PauliString` to a different coefficient type `ctype`.
-
-# Examples
-```julia
-converttype(Float64, PauliString(2, :X, 1, 1+0im))
-```
-"""
-function converttype(ctype::CT, pstr::PauliString) where {CT}
-    return PauliString(pstr.nqubits, pstr.term, ctype(pstr.coeff))
+# Conversion of PauliString and PauliSum to different coefficient types
+function Base.convert(::Type{PauliString{TT1,CT1}}, pstr::PauliString{TT2,CT2}) where {TT1,TT2,CT1,CT2}
+    if TT1 != TT2
+        throw(ArgumentError("Cannot change term type from $TT2 to $TT1"))
+    end
+    return PauliString(pstr.nqubits, convert(TT1, pstr.term), convert(CT1, pstr.coeff))
 end
 
-"""
-    converttype(ctype::Type, psum::PauliSum)
-
-Convert a `PauliSum` to a different coefficient type `ctype`.
-
-# Examples
-```julia
-psum = PauliSum(PauliString(2, :X, 1, 1+0im))
-converttype(Float64, psum)
-```
-"""
-function converttype(ctype::CT, psum::PauliSum) where {CT}
-
-    new_psum = PauliSum(ctype, psum.nqubits)
-
-    for (pstr, coeff) in psum
-        add!(new_psum, pstr, ctype(coeff))
+function Base.convert(::Type{PauliSum{TT1,CT1}}, psum::PauliSum{TT2,CT2}) where {TT1,TT2,CT1,CT2}
+    if TT1 != TT2
+        throw(ArgumentError("Cannot change term type from $TT2 to $TT1"))
     end
-    return new_psum
+    return PauliSum(pstr.nqubits, convert(Dict{TT1,CT1}, psum.terms))
+
+end
+
+# # Examples
+# ```julia
+# convertcoefftype(Float64, PauliString(2, :X, 1, 1+0im))
+# ```
+# """
+function convertcoefftype(::Type{CT1}, pstr::PauliString{TT,CT2}) where {TT,CT1,CT2}
+    return PauliString(pstr.nqubits, pstr.term, convert(CT1, pstr.coeff))
+end
+
+# # Examples
+# ```julia
+# psum = PauliSum(PauliString(2, :X, 1, 1+0im))
+# convertcoefftype(Float64, psum)
+# ```
+# """
+function convertcoefftype(::Type{CT1}, psum::PauliSum{TT,CT2}) where {TT,CT1,CT2}
+    return PauliSum(psum.nqubits, convert(Dict{TT,CT1}, psum.terms))
 end

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -40,7 +40,7 @@ export
     pauliprod,
     commutes,
     commutator,
-    converttype,
+    convertcoefftype,
     getinttype
 
 include("PauliTransferMatrix/PauliTransferMatrix.jl")

--- a/test/test_paulialgebra_utils.jl
+++ b/test/test_paulialgebra_utils.jl
@@ -117,10 +117,10 @@ end
 
     @testset "PauliString" begin
         pstr = PauliString(2, :X, 1, 1+0im)
-        @test converttype(Float64, pstr) == PauliString(2, :X, 1, 1.)
+        @test convertcoefftype(Float64, pstr) == PauliString(2, :X, 1, 1.)
 
         pstr = PauliString(2, [:X, :Y], [1, 2], 1)
-        @test converttype(ComplexF64, pstr) == PauliString(2, [:X, :Y], [1, 2], 1+0im)
+        @test convertcoefftype(ComplexF64, pstr) == PauliString(2, [:X, :Y], [1, 2], 1+0im)
     end
 
     @testset "PauliSum" begin
@@ -130,7 +130,7 @@ end
         expected_psum = PauliSum(2)
         add!(expected_psum, [:X, :Y], [1, 2], 2)
         add!(expected_psum, :Z, 1, 1)
-        @test converttype(Float64, psum) == expected_psum
+        @test convertcoefftype(Float64, psum) == expected_psum
     end
 
 end


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/MSRudolph/PauliPropagation.jl/issues/113#issue-3331764198) for converting coefficient types for PauliString and PauliSum. 
- Added converttype for PauliString and PauliSum and their tests.
- Added tests. 

For some reason, defining `convert(...)` raises conflicts with tests using Yao.jl. Seems like it would conflict with `Base.convert`. But happy to change the name 