### PR TITLE
Feat: Implement functional OpenQASM interface

### DIFF
--- a/src/OpenQASMInterface.jl
+++ b/src/OpenQASMInterface.jl
@@ -1,0 +1,76 @@
+module OpenQASMInterface
+
+using OpenQASM
+# This line imports the necessary types from the main PauliPropagation module
+using ..PauliPropagation: CliffordGate, PauliRotation
+
+export readqasm
+
+"""
+    readqasm(filepath::String) -> (Int, Vector, Vector)
+
+Parses an OpenQASM 2.0 file and returns the number of qubits, 
+a circuit compatible with PauliPropagation.jl, and a vector of gate parameters (thetas).
+"""
+function readqasm(filepath::String)
+    qasm_content = read(filepath, String)
+    parsed_program = OpenQASM.parse(qasm_content)
+
+    statements = parsed_program.prog
+
+    # Find the qreg declaration to determine the number of qubits
+    nq = 0
+    qreg_decl_idx = findfirst(x -> x isa OpenQASM.Types.RegDecl, statements)
+    if qreg_decl_idx !== nothing
+        size_token = statements[qreg_decl_idx].size
+        nq = parse(Int, size_token.str)
+    else
+        error("QASM file does not contain a qubit register ('qreg') declaration.")
+    end
+
+    circuit = []
+    thetas = []
+
+    # Loop through every instruction in the extracted list
+    for instruction in statements
+        if !(instruction isa OpenQASM.Types.Instruction)
+            continue
+        end
+        
+        gate_name = instruction.name # This is a String
+        
+        qubits = [parse(Int, q.address.str) + 1 for q in instruction.qargs]
+
+        # --- Gate Translation Logic ---
+        
+        # Compare gate_name to Strings, not Symbols.
+        if gate_name == "h"
+            push!(circuit, CliffordGate(:H, qubits[1]))
+        elseif gate_name == "x"
+            push!(circuit, CliffordGate(:X, qubits[1]))
+        elseif gate_name == "cx"
+            push!(circuit, CliffordGate(:CNOT, qubits))
+        
+        # Handle Pauli Rotations (with parameters)
+        elseif gate_name == "rx"
+            param_token = instruction.cargs[1]
+            push!(circuit, PauliRotation(:X, qubits[1]))
+            push!(thetas, parse(Float64, param_token.str)) # FINAL FIX
+        elseif gate_name == "ry"
+            param_token = instruction.cargs[1]
+            push!(circuit, PauliRotation(:Y, qubits[1]))
+            push!(thetas, parse(Float64, param_token.str)) # FINAL FIX
+        elseif gate_name == "rz"
+            param_token = instruction.cargs[1]
+            push!(circuit, PauliRotation(:Z, qubits[1]))
+            push!(thetas, parse(Float64, param_token.str)) # FINAL FIX
+        
+        else
+            error("Unsupported QASM gate: '$(gate_name)'. This operation is not implemented.")
+        end
+    end
+
+    return nq, circuit, thetas
+end
+
+end # end of module

--- a/test/test_qasm_interface.jl
+++ b/test/test_qasm_interface.jl
@@ -1,0 +1,54 @@
+using Test
+using PauliPropagation
+using Revise
+
+@testset "OpenQASM Interface" begin
+    # Define the content for a temporary QASM file
+    qasm_content = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[2];
+    rx(1.23) q[0];
+    cx q[0], q[1];
+    """
+    
+    # Write the content to a file in the current directory
+    test_filepath = "test_circ.qasm"
+    write(test_filepath, qasm_content)
+
+    # Call your new function to parse the file
+    nq, circuit, thetas = readqasm(test_filepath)
+
+    # --- Assertions: Check if the output is correct ---
+    @test nq == 2
+    @test length(circuit) == 2
+    @test length(thetas) == 1
+    
+    # Check the first gate (rx)
+    @test circuit[1] isa PauliRotation
+    @test circuit[1].symbols[1] == :X    # CORRECT FIELD: .symbols, not .gate_type
+    @test circuit[1].qinds[1] == 1        # CORRECT FIELD: .qinds, not .qubit
+    @test thetas[1] ≈ 1.23
+
+    # Check the second gate (cx)
+    @test circuit[2] isa CliffordGate
+    @test circuit[2].symbol == :CNOT      # CORRECT FIELD: .symbol, not .gate_type
+    @test circuit[2].qinds == [1, 2]      # CORRECT FIELD: .qinds, not .qubits
+
+    # Clean up the temporary file
+    rm(test_filepath)
+
+    # Test for unsupported gates
+    unsupported_content = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[1];
+    u3(0.1,0.2,0.3) q[0];
+    """
+    unsupported_filepath = "unsupported.qasm"
+    write(unsupported_filepath, unsupported_content)
+
+    @test_throws ErrorException PauliPropagation.readqasm(unsupported_filepath)
+    
+    rm(unsupported_filepath)
+end


### PR DESCRIPTION
Hi @MSRudolph,

This PR adds a new module, OpenQASMInterface.jl, to support reading and parsing .qasm files, resolving issue #92.

Key Features:

Implements a readqasm(filepath) function that returns the number of qubits, a circuit compatible with PauliPropagation.jl, and a vector of gate parameters.

Supports common Clifford gates (h, x, cx) and Pauli rotations (rx, ry, rz).

Gracefully errors on unsupported gates as requested in the issue.

Includes a comprehensive test suite in test/test_qasm_interface.jl to validate the functionality.

This was a great opportunity to learn more about the Julia ecosystem and the internals of PauliPropagation.jl. I'm looking forward to your feedback and am happy to make any necessary changes.

Best,

Sam