### PR TITLE
docs: embed example notebooks in documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,6 +68,14 @@ jobs:
         with:
           version: '1'
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install notebook converter
+        run: python -m pip install nbconvert
+
       # using cache speeds up workflow
       - name: Setup Julia cache
         uses: julia-actions/cache@v2

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,6 +56,47 @@ const EXAMPLE_PAGES = [
     for (notebook, title) in EXAMPLE_NOTEBOOKS
 ]
 
+# Documenter parses unescaped dollar signs in Markdown as Julia interpolation.
+function escape_documenter_dollars(line)
+    io = IOBuffer()
+    escaped = false
+
+    for char in line
+        if char == '$' && !escaped
+            print(io, "\\\$")
+        else
+            print(io, char)
+        end
+
+        escaped = char == '\\' && !escaped
+        if char != '\\'
+            escaped = false
+        end
+    end
+
+    return String(take!(io))
+end
+
+function escape_documenter_dollars!(markdown_path)
+    lines = readlines(markdown_path; keep=true)
+    converted = String[]
+    in_code_fence = false
+
+    for line in lines
+        stripped = lstrip(line)
+        if startswith(stripped, "```") || startswith(stripped, "~~~")
+            in_code_fence = !in_code_fence
+            push!(converted, line)
+        elseif in_code_fence || startswith(line, "    ")
+            push!(converted, line)
+        else
+            push!(converted, escape_documenter_dollars(line))
+        end
+    end
+
+    write(markdown_path, join(converted))
+end
+
 function convert_example_notebooks()
     if !isdir(EXAMPLES_DIR)
         error("Could not find examples directory at $(EXAMPLES_DIR)")
@@ -78,6 +119,9 @@ function convert_example_notebooks()
             "--output-dir", GENERATED_EXAMPLES_DIR,
             notebook_path,
         ]))
+
+        markdown_path = joinpath(GENERATED_EXAMPLES_DIR, replace(notebook, r"\.ipynb$" => ".md"))
+        escape_documenter_dollars!(markdown_path)
     end
 end
 
@@ -92,6 +136,8 @@ makedocs(
         assets=[
             "assets/favicon.ico",
         ],
+        size_threshold=2 * 2^20,
+        size_threshold_warn=512 * 2^10,
     ), sitename="PauliPropagation.jl",
 
     # determines site layout

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,6 +27,64 @@
 using Documenter, PauliPropagation
 
 
+const DOCS_DIR = @__DIR__
+const REPO_ROOT = dirname(DOCS_DIR)
+const EXAMPLES_DIR = joinpath(REPO_ROOT, "examples")
+const GENERATED_EXAMPLES_DIR = joinpath(DOCS_DIR, "src", "examples")
+
+const EXAMPLE_NOTEBOOKS = [
+    "1-basic-example.ipynb" => "Basic Example",
+    "2-datatypes.ipynb" => "Data Types",
+    "3-utility-example.ipynb" => "Utility Functions",
+    "4-pauli-transfer-matrix.ipynb" => "Pauli Transfer Matrix",
+    "5-custom-gates.ipynb" => "Custom Gates",
+    "6-numerical-certificate.ipynb" => "Numerical Certificates",
+    "7-custom-pathproperties.ipynb" => "Custom Path Properties",
+    "8-automatic-differentiation.ipynb" => "Automatic Differentiation",
+    "9-advanced-custom-gates.ipynb" => "Advanced Custom Gates",
+    "introduction-example-error-mitigation.ipynb" => "Error Mitigation",
+    "imaginary-time-evolution.ipynb" => "Imaginary Time Evolution",
+    "PP-Surrogate.ipynb" => "Pauli Propagation Surrogate",
+    "PP-from-Python.ipynb" => "Using PauliPropagation.jl from Python",
+    "Symmetry-PP.ipynb" => "Symmetry",
+    "visualization_example.ipynb" => "Visualization",
+    "ex_ttfi_op_evolution.ipynb" => "TTFI Operator Evolution",
+]
+
+const EXAMPLE_PAGES = [
+    title => joinpath("examples", replace(notebook, r"\.ipynb$" => ".md"))
+    for (notebook, title) in EXAMPLE_NOTEBOOKS
+]
+
+function convert_example_notebooks()
+    if !isdir(EXAMPLES_DIR)
+        error("Could not find examples directory at $(EXAMPLES_DIR)")
+    end
+
+    rm(GENERATED_EXAMPLES_DIR; recursive=true, force=true)
+    mkpath(GENERATED_EXAMPLES_DIR)
+
+    jupyter = get(ENV, "JUPYTER", "jupyter")
+    for (notebook, _) in EXAMPLE_NOTEBOOKS
+        notebook_path = joinpath(EXAMPLES_DIR, notebook)
+        if !isfile(notebook_path)
+            error("Could not find example notebook at $(notebook_path)")
+        end
+
+        run(Cmd([
+            jupyter,
+            "nbconvert",
+            "--to", "markdown",
+            "--output-dir", GENERATED_EXAMPLES_DIR,
+            notebook_path,
+        ]))
+    end
+end
+
+
+convert_example_notebooks()
+
+
 # Generate doc HTML files, saved to build/
 makedocs(
     # Add favicon.ico
@@ -50,8 +108,10 @@ makedocs(
         # these other 'top-level' files DO exist, and
         # have names inferred from their section names
 
-        # TODO: add this back once we know how to embed the Jupyter notebooks
-        # "tutorials.md",
+        "Tutorials" => "tutorials.md",
+
+        # generated from examples/*.ipynb by convert_example_notebooks()
+        "Examples" => EXAMPLE_PAGES,
 
         # these 'lower-level' files also exist, and will
         # be grouped under an 'API' section in the navbar

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,5 @@
 # Generates HTML documentation from the contents of
-# the docs folder. To generate, we must first setup
-# a symlink from the repo README.md to src/index.md,
-# in order re-use the README in Documenter.jl
-# From the docs/ directory (containing this file):
-#     cd src
-#     ln -s ../../README.md index.md
-#     cd ../
-#
-# This need only be done once per-machine. Then,
-# generating/updating the doc is triggered via
+# the docs folder. To generate/update the docs, run:
 #     julia --project make.jl
 # 
 # If triggered within a Github Action, the generated
@@ -29,8 +20,10 @@ using Documenter, PauliPropagation
 
 const DOCS_DIR = @__DIR__
 const REPO_ROOT = dirname(DOCS_DIR)
+const DOCS_SRC_DIR = joinpath(DOCS_DIR, "src")
+const INDEX_PAGE = joinpath(DOCS_SRC_DIR, "index.md")
 const EXAMPLES_DIR = joinpath(REPO_ROOT, "examples")
-const GENERATED_EXAMPLES_DIR = joinpath(DOCS_DIR, "src", "examples")
+const GENERATED_EXAMPLES_DIR = joinpath(DOCS_SRC_DIR, "examples")
 
 const EXAMPLE_NOTEBOOKS = [
     "1-basic-example.ipynb" => "Basic Example",
@@ -125,7 +118,25 @@ function convert_example_notebooks()
     end
 end
 
+function ensure_index_page()
+    if ispath(INDEX_PAGE)
+        return
+    end
 
+    readme_path = joinpath(REPO_ROOT, "README.md")
+    if !isfile(readme_path)
+        error("Could not find README.md at $(readme_path)")
+    end
+
+    try
+        symlink(relpath(readme_path, DOCS_SRC_DIR), INDEX_PAGE)
+    catch
+        cp(readme_path, INDEX_PAGE)
+    end
+end
+
+
+ensure_index_page()
 convert_example_notebooks()
 
 
@@ -143,10 +154,9 @@ makedocs(
     # determines site layout
     pages=[
 
-        # index.md does not exist; it is a symlink
-        # to the repo's README.md file, created as
-        # per the comments above, to avoid duplicating
-        # the README.md contents into Documenter.jl 
+        # index.md is linked or copied from the repo's
+        # README.md by ensure_index_page(), avoiding
+        # README duplication in Documenter.jl
         # pages. We manually override its name in the
         # left navbar to be "Introduction"
         "Home" => "index.md",

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -1,3 +1,6 @@
 # Tutorials
 
-> TODO
+The example notebooks in the repository's `examples/` directory are converted
+into documentation pages when the docs are built.
+
+Use the Examples section in the sidebar to browse the rendered notebooks.


### PR DESCRIPTION
Closes #143.

## Summary
- convert the notebooks in `examples/` to Markdown pages during the docs build with `jupyter nbconvert`
- add the generated notebook pages under an Examples section in the Documenter navigation
- replace the placeholder tutorials page with a short pointer to the rendered notebook examples
- install `nbconvert` in the documentation workflow so PR previews can build the generated pages
- escape dollar signs in generated Markdown text so notebook math does not trigger Documenter interpolation warnings
- raise the Documenter HTML page-size threshold for notebook pages with embedded outputs

## Verification
- Ran `git diff --check`
- Ran the full docs build locally with Julia 1.12.6 and nbconvert 7.17.1:
  `JULIA_DEPOT_PATH=... JUPYTER=... julia --color=yes --project=docs docs/make.jl`
- The docs build converted all 16 notebooks, rendered HTML pages, and exited successfully
- GitHub Actions for this PR are currently `action_required`, so the upstream preview workflow has not run yet

## AI assistance disclosure
I used Codex to inspect the docs setup, draft the integration, and run local conversion/build checks; the generated notebook conversion output and diff were manually reviewed before submission.
