### PR TITLE
Noise variable renaming

### DIFF
--- a/src/Gates/noisechannels.jl
+++ b/src/Gates/noisechannels.jl
@@ -6,7 +6,7 @@
 ###
 
 
-# Depolarzing noise channel
+# Depolarizing noise channel
 """
 Abstract type for parametrized noise channels.
 """
@@ -31,7 +31,8 @@ struct DepolarizingNoise <: PauliNoise
     A depolarizing noise channel acting on the qubit at index `qind`.
     If `lambda` is provided, this returns a frozen gate with that noise strength.
     Will damp X, Y, and Z Paulis equally by a factor of `1-lambda`.
-    This corresponds to inserting a random Pauli operator into the circuit with probability `p=lambda`.
+    In the Schrödinger picture, this corresponds to inserting a random X, Y, or Z 
+    Pauli operator into the circuit with probability `p=lambda`.
     """
     DepolarizingNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
@@ -62,7 +63,8 @@ struct PauliXNoise <: PauliNoise
     A Pauli-X noise channel acting on the qubit at index `qind`.
     If `lambda` is provided, this returns a frozen gate with that noise strength.
     Will damp Y and Z Paulis equally by a factor of `1-lambda`.
-    This corresponds to inserting a Pauli X operator into the circuit with probability `p=lambda/2`.
+    In the Schrödinger picture, this corresponds to inserting a random X 
+    Pauli operator into the circuit with probability `p=lambda/2`.
     """
     PauliXNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
@@ -94,7 +96,8 @@ struct PauliYNoise <: PauliNoise
     A Pauli-Y noise channel acting on the qubit at index `qind`.
     If `lambda` is provided, this returns a frozen gate with that noise strength.
     Will damp X and Z Paulis equally by a factor of `1-lambda`.
-    This corresponds to inserting a Pauli Y operator into the circuit with probability `p=lambda/2`.
+    In the Schrödinger picture, this corresponds to inserting a random Y 
+    Pauli operator into the circuit with probability `p=lambda/2`.
     """
     PauliYNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
@@ -126,7 +129,8 @@ struct PauliZNoise <: PauliNoise
     A Pauli-Z noise channel acting on the qubit at index `qind`.
     If `lambda` is provided, this returns a frozen gate with that noise strength.
     Will damp X and Y Paulis equally by a factor of `1-lambda`.
-    This corresponds to inserting a Pauli Z operator with probability `p=lambda/2`.
+    In the Schrödinger picture, this corresponds to inserting a random Z 
+    Pauli operator into the circuit with probability `p=lambda/2`.
     """
     PauliZNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
@@ -154,7 +158,8 @@ This is an alias for `PauliZNoise`.
 If `lambda` is provided, this returns a frozen gate with that noise strength.
 A dephasing noise channel acting on the qubit at index `qind`.
 Will damp X and Y Paulis equally by a factor of `1-lambda`.
-This corresponds to inserting a Pauli Z operator with probability `p=lambda/2`.
+In the Schrödinger picture, this corresponds to inserting a random Z 
+Pauli operator into the circuit with probability `p=lambda/2`.
 """
 const DephasingNoise = PauliZNoise
 
@@ -253,7 +258,7 @@ struct AmplitudeDampingNoise <: ParametrizedNoiseChannel
     An amplitude damping noise channel acting on the qubit at index `qind`.
     If `gamma` is provided, this returns a frozen gate with that noise strength.
     Damps X and Y Paulis by a factor of sqrt(1-gamma)
-    and splits Z into and gamma * I and (1-gamma) * Z component (in the transposed Heisenberg picture).
+    and splits Z into gamma * I and (1-gamma) * Z component (in the transposed Heisenberg picture).
     """
     AmplitudeDampingNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end

--- a/src/Gates/noisechannels.jl
+++ b/src/Gates/noisechannels.jl
@@ -26,21 +26,22 @@ struct DepolarizingNoise <: PauliNoise
 
     @doc """
         DepolarizingNoise(qind::Int)
-        DepolarizingNoise(qind::Int, p::Real)
+        DepolarizingNoise(qind::Int, lambda::Real)
 
     A depolarizing noise channel acting on the qubit at index `qind`.
-    If `p` is provided, this returns a frozen gate with that noise strength.
-    Will damp X, Y, and Z Paulis equally by a factor of `1-p`.
+    If `lambda` is provided, this returns a frozen gate with that noise strength.
+    Will damp X, Y, and Z Paulis equally by a factor of `1-lambda`.
+    This corresponds to inserting a random Pauli operator into the circuit with probability `p=lambda`.
     """
     DepolarizingNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function DepolarizingNoise(qind::Int, p::Real)
-    _check_noise_strength(DepolarizingNoise, p)
+function DepolarizingNoise(qind::Int, lambda::Real)
+    _check_noise_strength(DepolarizingNoise, lambda)
 
-    return FrozenGate(DepolarizingNoise(qind), p)
+    return FrozenGate(DepolarizingNoise(qind), lambda)
 end
 
 function isdamped(::DepolarizingNoise, pauli::PauliType)
@@ -56,22 +57,22 @@ struct PauliXNoise <: PauliNoise
 
     @doc """
         PauliXNoise(qind::Int)
-        PauliXNoise(qind::Int, p::Real)
+        PauliXNoise(qind::Int, lambda::Real)
 
     A Pauli-X noise channel acting on the qubit at index `qind`.
-    If `p` is provided, this returns a frozen gate with that noise strength.
-    Will damp Y and Z Paulis equally by a factor of `1-p`.
-    This corresponds to inserting a Pauli X operator into the circuit with probability `p/2`.
+    If `lambda` is provided, this returns a frozen gate with that noise strength.
+    Will damp Y and Z Paulis equally by a factor of `1-lambda`.
+    This corresponds to inserting a Pauli X operator into the circuit with probability `p=lambda/2`.
     """
     PauliXNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function PauliXNoise(qind::Int, p::Real)
-    _check_noise_strength(DephasingNoise, p)
+function PauliXNoise(qind::Int, lambda::Real)
+    _check_noise_strength(PauliXNoise, lambda)
 
-    return FrozenGate(PauliXNoise(qind), p)
+    return FrozenGate(PauliXNoise(qind), lambda)
 end
 
 
@@ -88,22 +89,22 @@ struct PauliYNoise <: PauliNoise
 
     @doc """
         PauliYNoise(qind::Int)
-        PauliYNoise(qind::Int, p::Real)
+        PauliYNoise(qind::Int, lambda::Real)
 
     A Pauli-Y noise channel acting on the qubit at index `qind`.
-    If `p` is provided, this returns a frozen gate with that noise strength.
-    Will damp X and Z Paulis equally by a factor of `1-p`.
-    This corresponds to inserting a Pauli Y operator into the circuit with probability `p/2`.
+    If `lambda` is provided, this returns a frozen gate with that noise strength.
+    Will damp X and Z Paulis equally by a factor of `1-lambda`.
+    This corresponds to inserting a Pauli Y operator into the circuit with probability `p=lambda/2`.
     """
     PauliYNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function PauliYNoise(qind::Int, p::Real)
-    _check_noise_strength(DephasingNoise, p)
+function PauliYNoise(qind::Int, lambda::Real)
+    _check_noise_strength(PauliYNoise, lambda)
 
-    return FrozenGate(PauliYNoise(qind), p)
+    return FrozenGate(PauliYNoise(qind), lambda)
 end
 
 
@@ -120,22 +121,22 @@ struct PauliZNoise <: PauliNoise
 
     @doc """
         PauliZNoise(qind::Int)
-        PauliZNoise(qind::Int, p::Real)
+        PauliZNoise(qind::Int, lambda::Real)
 
     A Pauli-Z noise channel acting on the qubit at index `qind`.
-    If `p` is provided, this returns a frozen gate with that noise strength.
-    Will damp X and Y Paulis equally by a factor of `1-p`.
-    This corresponds to inserting a Pauli Z operator with probability `p/2`.
+    If `lambda` is provided, this returns a frozen gate with that noise strength.
+    Will damp X and Y Paulis equally by a factor of `1-lambda`.
+    This corresponds to inserting a Pauli Z operator with probability `p=lambda/2`.
     """
     PauliZNoise(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version 
-function PauliZNoise(qind::Int, p::Real)
-    _check_noise_strength(DephasingNoise, p)
+function PauliZNoise(qind::Int, lambda::Real)
+    _check_noise_strength(PauliZNoise, lambda)
 
-    return FrozenGate(PauliZNoise(qind), p)
+    return FrozenGate(PauliZNoise(qind), lambda)
 end
 
 
@@ -147,12 +148,13 @@ end
 ## DephasingNoise is an alias for PauliZNoise
 """
     DephasingNoise(qind::Int)
-    DephasingNoise(qind::Int, p::Real)
+    DephasingNoise(qind::Int, lambda::Real)
 
 This is an alias for `PauliZNoise`.
-If `p` is provided, this returns a frozen gate with that noise strength.
+If `lambda` is provided, this returns a frozen gate with that noise strength.
 A dephasing noise channel acting on the qubit at index `qind`.
-Will damp X and Y Paulis equally by a factor of `1-p`.
+Will damp X and Y Paulis equally by a factor of `1-lambda`.
+This corresponds to inserting a Pauli Z operator with probability `p=lambda/2`.
 """
 const DephasingNoise = PauliZNoise
 
@@ -164,21 +166,21 @@ struct PauliXDamping <: PauliNoise
     qind::Int
 
     #     PauliXDamping(qind::Int)
-    #     PauliXDamping(qind::Int, p::Real)
+    #     PauliXDamping(qind::Int, lambda::Real)
 
     # A Pauli-X noise damping acting on the qubit at index `qind`.
-    # If `p` is provided, this returns a frozen gate with that damping strength.
-    # Will damp X Paulis by a factor of `1-p`. 
+    # If `lambda` is provided, this returns a frozen gate with that damping strength.
+    # Will damp X Paulis by a factor of `1-lambda`. 
     # This alone is not a valid quantum channel.
     PauliXDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function PauliXDamping(qind::Int, p::Real)
-    _check_noise_strength(PauliXDamping, p)
+function PauliXDamping(qind::Int, lambda::Real)
+    _check_noise_strength(PauliXDamping, lambda)
 
-    return FrozenGate(PauliXDamping(qind), p)
+    return FrozenGate(PauliXDamping(qind), lambda)
 end
 
 
@@ -193,18 +195,18 @@ struct PauliYDamping <: PauliNoise
     #     PauliYDamping(qind::Int)
 
     # A Pauli-Y noise damping acting on the qubit at index `qind`.
-    # If `p` is provided, this returns a frozen gate with that damping strength.
-    # Will damp Y Paulis by a factor of `1-p`. 
+    # If `lambda` is provided, this returns a frozen gate with that damping strength.
+    # Will damp Y Paulis by a factor of `1-lambda`. 
     # This alone is not a valid quantum channel.
     PauliYDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function PauliYDamping(qind::Int, p::Real)
-    _check_noise_strength(PauliYDamping, p)
+function PauliYDamping(qind::Int, lambda::Real)
+    _check_noise_strength(PauliYDamping, lambda)
 
-    return FrozenGate(PauliYDamping(qind), p)
+    return FrozenGate(PauliYDamping(qind), lambda)
 end
 
 
@@ -219,18 +221,18 @@ struct PauliZDamping <: PauliNoise
     #     PauliZDamping(qind::Int)
 
     # A Pauli-Z noise damping acting on the qubit at index `qind`.
-    # If `p` is provided, this returns a frozen gate with that damping strength.
-    # Will damp Z Paulis by a factor of `1-p`. 
+    # If `lambda` is provided, this returns a frozen gate with that damping strength.
+    # Will damp Z Paulis by a factor of `1-lambda`. 
     # This alone is not a valid quantum channel.
     PauliZDamping(qind::Int) = (_qinds_check(qind); new(qind))
 end
 
 
 # the frozen gate version
-function PauliZDamping(qind::Int, p::Real)
-    _check_noise_strength(PauliZDamping, p)
+function PauliZDamping(qind::Int, lambda::Real)
+    _check_noise_strength(PauliZDamping, lambda)
 
-    return FrozenGate(PauliZDamping(qind), p)
+    return FrozenGate(PauliZDamping(qind), lambda)
 end
 
 function isdamped(::PauliZDamping, pauli::PauliType)
@@ -265,8 +267,8 @@ function AmplitudeDampingNoise(qind::Int, gamma::Real)
 end
 
 
-function _check_noise_strength(::Type{G}, p) where {G<:ParametrizedNoiseChannel}
-    if !(0 <= p <= 1)
-        throw(ArgumentError("$G parameter must be between 0 and 1. Got $p."))
+function _check_noise_strength(::Type{G}, lambda::Real) where {G<:ParametrizedNoiseChannel}
+    if !(0 <= lambda <= 1)
+        throw(ArgumentError("$G parameter must be between 0 and 1. Got $lambda."))
     end
 end

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -202,16 +202,16 @@ end
 
 ### Pauli Noise
 """
-    applytoall!(gate::PauliNoise, prop_cache::PauliPropagationCache, p; kwargs...)
+    applytoall!(gate::PauliNoise, prop_cache::PauliPropagationCache, lambda; kwargs...)
 
-Overload of `applytoall!` for `PauliNoise` gates with noise strength `p` and a propagating `PauliSum`.
+Overload of `applytoall!` for `PauliNoise` gates with noise strength `lambda` and a propagating `PauliSum`.
 """
-function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::PauliPropagationCache, p; kwargs...)
+function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::PauliPropagationCache, lambda; kwargs...)
     # unpack the main pauli sum, aux is not needed
     psum = mainsum(prop_cache)
 
     # check that the noise strength is in the correct range
-    _check_noise_strength(PauliNoise, p)
+    _check_noise_strength(PauliNoise, lambda)
 
     # loop over all Pauli strings and their coefficients in the Pauli sum
     for (pstr, coeff) in psum
@@ -225,7 +225,7 @@ function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::PauliPropagat
             continue
         end
 
-        new_coeff = coeff * (1 - p)
+        new_coeff = coeff * (1 - lambda)
         # change the coefficient in psum, don't move anything to aux_psum
         set!(psum, pstr, new_coeff)
     end

--- a/src/Propagation/vectorspecializations.jl
+++ b/src/Propagation/vectorspecializations.jl
@@ -211,14 +211,14 @@ requiresmerging(::CliffordGate) = false
 ##########################################
 
 """
-    applytoall!(gate::PauliNoise, prop_cache::VectorPauliPropagationCache, p; kwargs...)
+    applytoall!(gate::PauliNoise, prop_cache::VectorPauliPropagationCache, lambda; kwargs...)
 
-Overload of `applytoall!` for `PauliNoise` gates with noise strength `p` and a propagating `VectorPauliSum`.
+Overload of `applytoall!` for `PauliNoise` gates with noise strength `lambda` and a propagating `VectorPauliSum`.
 """
-function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::VectorPauliPropagationCache, p; kwargs...)
+function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::VectorPauliPropagationCache, lambda; kwargs...)
 
     # check that the noise strength is in the correct range
-    _check_noise_strength(PauliNoise, p)
+    _check_noise_strength(PauliNoise, lambda)
 
     # everything is done in place
     terms_view = activeterms(prop_cache)
@@ -231,7 +231,7 @@ function PropagationBase.applytoall!(gate::PauliNoise, prop_cache::VectorPauliPr
         pauli = getpauli(pstr, gate.qind)
 
         if isdamped(gate, pauli)
-            coeffs_view[ii] = coeff * (1 - p)
+            coeffs_view[ii] = coeff * (1 - lambda)
         end
     end
 


### PR DESCRIPTION
- Rename Pauli noise strength `p` to `lambda` to disambiguate with the error probability. 
- Adapt docstrings accordingly