### PR TITLE
Speedups to truncate!() for PauliSum

### DIFF
--- a/src/Base/truncate.jl
+++ b/src/Base/truncate.jl
@@ -33,11 +33,7 @@ function _truncate!(::DictStorage, truncfunc::F, prop_cache::AbstractPropagation
 end
 
 function _truncate!(::DictStorage, truncfunc::F, term_sum::AbstractTermSum; kwargs...) where F<:Function
-    for (pstr, coeff) in term_sum
-        if truncfunc(pstr, coeff)
-            delete!(term_sum, pstr)
-        end
-    end
+    filter!(_invertfunc(truncfunc), storage(term_sum))
     return term_sum
 end
 

--- a/src/Base/utils.jl
+++ b/src/Base/utils.jl
@@ -1,5 +1,7 @@
 tonumber(x::Number) = x
 
+_invertfunc(func::F) where {F<:Function} = args -> !func(args...)
+
 function _thrownotimplemented(::Type{T}, func_name::Symbol) where T
     error("Function '", func_name, "' not implemented for type '", T, "'.")
 end

--- a/src/Propagation/generics.jl
+++ b/src/Propagation/generics.jl
@@ -138,9 +138,9 @@ function PropagationBase.truncate!(psum::AbstractPauliSum; min_abs_coeff::Real=1
 
     function truncfunc(pstr, coeff)
         is_truncated = false
-        if truncateweight(pstr, max_weight)
+        if truncatemincoeff(coeff, min_abs_coeff)
             is_truncated = true
-        elseif truncatemincoeff(coeff, min_abs_coeff)
+        elseif truncateweight(pstr, max_weight)
             is_truncated = true
         elseif truncatefrequency(coeff, max_freq)
             is_truncated = true

--- a/src/truncations.jl
+++ b/src/truncations.jl
@@ -40,6 +40,9 @@ end
 
 # Return `true` if an integer Pauli string should be truncated because its weight (i.e., number of non-identity Paulis) is larger than `max_weight`. 
 function truncateweight(pstr::Integer, max_weight::Real)
+    if isinf(max_weight)
+        return false
+    end
     return countweight(pstr) > max_weight
 end
 


### PR DESCRIPTION
- Using `Base.filter!()` for Base.Dict uses internals to more quickly delete a series of objects.
- Moved up our main coefficient truncation to the first slot.
- Check for `Inf` threshold before counting Pauli weight.
