### PR TITLE
 Sign convention in ImaginaryPauliRotation

### DIFF
--- a/examples/imaginary-time-evolution.ipynb
+++ b/examples/imaginary-time-evolution.ipynb
@@ -71,7 +71,7 @@
       "text/plain": [
        "PauliSum(nqubits: 8, 2 Pauli terms:\n",
        " 1.0 * IIIIIIII\n",
-       " 0.099668 * XIYIIIII\n",
+       " -0.099668 * XIYIIIII\n",
        ")"
       ]
      },
@@ -156,7 +156,7 @@
       "text/plain": [
        "PauliSum(nqubits: 8, 2 Pauli terms:\n",
        " 1.005 * IIIIIIII\n",
-       " 0.10017 * XIYIIIII\n",
+       " -0.10017 * XIYIIIII\n",
        ")"
       ]
      },
@@ -213,12 +213,11 @@
     "for i in 1:nq\n",
     "    push!(imaginary_circuit, ImaginaryPauliRotation([:X], [i]))\n",
     "    # in real-time there would be another factor of 2 here, but we already have the 1/2 factor in evolution definition\n",
-    "    push!(imaginary_params, -τ * h)\n",
+    "    push!(imaginary_params, τ * h)\n",
     "end\n",
     "for pair in topology\n",
     "    push!(imaginary_circuit, ImaginaryPauliRotation([:Z, :Z], pair))\n",
-    "    # the minus sign is important to lower temperature, i.e. evolve towards the ground state\n",
-    "    push!(imaginary_params, -τ * J)\n",
+    "    push!(imaginary_params, τ * J)\n",
     "end\n"
    ]
   },

--- a/src/Performance/fused_vector.jl
+++ b/src/Performance/fused_vector.jl
@@ -73,7 +73,7 @@ function PauliPropagation.applymergetruncate!(gate::PauliPropagation.ImaginaryPa
 
     truncfunc(pstr, coeff) = _fusedtruncfunc(pstr, coeff; min_abs_coeff, max_weight, max_freq, max_sins, customtruncfunc)
 
-    _fusedapplytruncaterotation!(prop_cache, gate_mask, cosh(tau), sinh(tau), PauliPropagation.imaginarypaulirotationproduct, truncfunc, Val(:ImaginaryPauliRotation); thread)
+    _fusedapplytruncaterotation!(prop_cache, gate_mask, cosh(tau), sinh(tau), PauliPropagation.paulirotationproduct, truncfunc, Val(:ImaginaryPauliRotation); thread)
 
     PauliPropagation.merge!(prop_cache; thread, truncfunc, kwargs...)
 

--- a/src/Propagation/specializations.jl
+++ b/src/Propagation/specializations.jl
@@ -134,9 +134,9 @@ function PauliPropagation.applytoall!(gate::ImaginaryPauliRotation, prop_cache::
         end
 
         coeff1 = coeff * cosh_val
-        # because of the imaginary time, we have take a normal product here
-        # given the commutation, the sign is always real
-        new_pstr, sign = imaginarypaulirotationproduct(gate_mask, pstr)
+        # paulirotationproduct's sign formula also gives the correct minus sign here:
+        # e^{-τ/2 P} Q e^{-τ/2 P} = cosh(τ) Q - sinh(τ) PQ for commuting P, Q
+        new_pstr, sign = paulirotationproduct(gate_mask, pstr)
         coeff2 = coeff * sinh_val * sign
 
         # set the coefficient of the original Pauli string
@@ -148,19 +148,6 @@ function PauliPropagation.applytoall!(gate::ImaginaryPauliRotation, prop_cache::
     end
 
     return
-end
-
-function imaginarypaulirotationproduct(gate_mask::TT, pstr::TT) where TT
-    new_pstr = PauliPropagation._bitpaulimultiply(gate_mask, pstr)
-
-    # this counts the exponent of the imaginary unit in the new Pauli string
-    im_count = PauliPropagation._calculatesignexponent(gate_mask, pstr)
-
-    # now, instead of computing real(im^im_count),
-    # we do this in one step via a cheeky trick:
-    sign = 1 - (im_count & 2)
-    # this is equivalent to sign = real(im^im_count)
-    return new_pstr, sign
 end
 
 

--- a/src/Propagation/vectorspecializations.jl
+++ b/src/Propagation/vectorspecializations.jl
@@ -162,7 +162,7 @@ function _applyimaginarypaulirotation!(prop_cache::VectorPauliPropagationCache, 
             coeff = coeffs[ii]
 
             coeff1 = coeff * cosh_val
-            new_term, sign = imaginarypaulirotationproduct(gate_mask, term)
+            new_term, sign = paulirotationproduct(gate_mask, term)
             coeff2 = coeff * sinh_val * sign
 
             coeffs[ii] = coeff1

--- a/test/test_imaginary.jl
+++ b/test/test_imaginary.jl
@@ -21,17 +21,107 @@
         rho_evolved = PropType(rho_cache_evolved)
         @test length(rho_evolved) == 2
         @test getcoeff(rho_evolved, 0) ≈ 1.0
-        @test sinh(tau) / cosh(tau) ≈ scalarproduct(rho_evolved, gate_pstr)
+        # e^{-τ/2 P} I e^{-τ/2 P} = cosh(τ) I - sinh(τ) P, normalized by cosh(τ)
+        @test -sinh(tau) / cosh(tau) ≈ scalarproduct(rho_evolved, gate_pstr)
 
         rho_cache = PropagationCache(deepcopy(rho_sum))
         rho_cache_evolved = propagate!(gate, rho_cache, tau; heisenberg=false, normalize_coeffs=false, min_abs_coeff=0)
         rho_evolved = PropType(rho_cache_evolved)
         @test length(rho_evolved) == 2
         @test cosh(tau) ≈ getcoeff(rho_evolved, 0) != 1.0
-        @test sinh(tau) ≈ scalarproduct(rho_evolved, gate_pstr)
+        @test -sinh(tau) ≈ scalarproduct(rho_evolved, gate_pstr)
 
 
         # default behavior is Heisenberg, which we currently don't support
         @test_throws ErrorException propagate(gate, rho, tau)
+    end
+end
+
+@testset "Test Imaginary Time Evolution Cools Towards the Ground State: diagonal Hamiltonian" begin
+    # a small Ising-type Hamiltonian, diagonal in the computational (Z) basis
+    nq = 4
+    hs = [0.6, -0.4, 0.9, -0.7]
+    pairs = [(1, 2), (2, 3), (3, 4)]
+    Js = [0.5, -0.6, 0.4]
+
+    H = PauliSum(nq)
+    for i in 1:nq
+        add!(H, :Z, i, hs[i])
+    end
+    for (k, (a, b)) in enumerate(pairs)
+        add!(H, [:Z, :Z], [a, b], Js[k])
+    end
+
+    # H is diagonal, so its ground energy is found by brute-force enumeration
+    # over all computational basis states
+    function _diagonalenergy(z)
+        e = sum(hs[i] * z[i] for i in 1:nq)
+        e += sum(Js[k] * z[a] * z[b] for (k, (a, b)) in enumerate(pairs))
+        return e
+    end
+    all_energies = [_diagonalenergy([b == 0 ? 1 : -1 for b in digits(s, base=2, pad=nq)]) for s in 0:(2^nq-1)]
+    E_ground = minimum(all_energies)
+
+    circuit = Gate[]
+    for i in 1:nq
+        push!(circuit, ImaginaryPauliRotation(:Z, i))
+    end
+    for (a, b) in pairs
+        push!(circuit, ImaginaryPauliRotation([:Z, :Z], [a, b]))
+    end
+    # all generators are diagonal, hence mutually commuting, so this
+    # Trotterization is exact regardless of step size, and a handful of large
+    # steps is as accurate as many small ones
+    step_params = vcat(1.0 .* hs, 1.0 .* Js)
+
+    rho = PauliString(nq, :I, 1)
+    energies = Float64[scalarproduct(H, rho)]
+    for _ in 1:10
+        rho = propagate!(circuit, rho, step_params; heisenberg=false, min_abs_coeff=0)
+        push!(energies, scalarproduct(H, rho))
+    end
+
+    # the natural, un-negated Hamiltonian coefficients must monotonically cool
+    # the state towards the ground state energy
+    @test issorted(energies, rev=true)
+    @test isapprox(energies[end], E_ground; atol=1e-2)
+end
+
+@testset "Test Imaginary Time Evolution Cools Towards the Ground State: product-state X Hamiltonian" begin
+    # a non-interacting Hamiltonian of single-qubit X terms, whose ground state
+    # is the exactly known product state of ±X eigenstates
+    nq = 4
+    h = [0.8, -0.5, 1.2, -0.3]
+
+    H = PauliSum(nq)
+    for i in 1:nq
+        add!(H, :X, i, h[i])
+    end
+    E_ground = -sum(abs.(h))
+
+    circuit = [ImaginaryPauliRotation(:X, i) for i in 1:nq]
+    # single-qubit terms all commute, so the Trotterization is exact regardless
+    # of step size, and a handful of large steps is as accurate as many small ones
+    tau = 1.0
+    step_params = tau .* h
+
+    rho = PauliString(nq, :I, 1)
+    energies = Float64[scalarproduct(H, rho)]
+    for layer in 1:10
+        rho = propagate!(circuit, rho, step_params; heisenberg=false, min_abs_coeff=0)
+        beta = layer * tau
+        # matches the closed-form thermal expectation value at every step
+        E_exact = -sum(h[i] * tanh(beta * h[i]) for i in 1:nq)
+        push!(energies, scalarproduct(H, rho))
+        @test energies[end] ≈ E_exact atol = 1e-9
+    end
+
+    @test issorted(energies, rev=true)
+    @test isapprox(energies[end], E_ground; atol=1e-2)
+
+    # the final state approaches the product state polarized opposite to each
+    # local field, i.e. <X_i> -> -sign(h_i)
+    for i in 1:nq
+        @test scalarproduct(PauliString(nq, :X, i), rho) ≈ -sign(h[i]) atol = 1e-2
     end
 end


### PR DESCRIPTION
- bugfix: sign convention in ImaginaryPauliRotations flipped was unintentionally flipped. Now parameter `tau` truly results in `exp(-tau/2` decay. Used to require `-tau`. Now consistent with docstring.
- Remove `imaginarypaulirotationproduct` as it is now unnecessary
- adapt and rerun example notebook